### PR TITLE
Change identifier names for Android and iOS apps

### DIFF
--- a/src/android/AndroidManifest.xml
+++ b/src/android/AndroidManifest.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.devoxx" android:versionCode="127" android:versionName="1.0">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.devoxx.mobile" android:versionCode="127" android:versionName="1.0">
         <supports-screens android:xlargeScreens="true"/>
         <uses-permission android:name="android.permission.INTERNET"/>
         <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>

--- a/src/ios/Default-Info.plist
+++ b/src/ios/Default-Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
         <key>CFBundleIdentifier</key>
-        <string>com.devoxx.DevoxxApplication</string>
+        <string>com.devoxx.mobile</string>
         <key>CFBundleVersion</key>
         <!-- buildnumber --><string>127</string>
         <key>CFBundleShortVersionString</key>


### PR DESCRIPTION
The identifier `com.devoxx` is already in use by the "My Devoxx" Android application. I renamed the package name for Android and the CFBundleIdentifier for iOS to `com.devoxx.mobile` instead.