### PR TITLE
Set a fixed project name

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'DevoxxClient'


### PR DESCRIPTION
The name of the parent folder is by default the name of the project. However, to make sure the IPA for iOS can be built consistently everywhere, we need a fixed name, as the name of the project must match the CFBundleExecutable key.