### PR TITLE
Apply ETag validation on image resources

### DIFF
--- a/DevoxxClientMobile/build.gradle
+++ b/DevoxxClientMobile/build.gradle
@@ -31,7 +31,7 @@ dependencies {
     
     compile 'com.gluonhq:glisten-afterburner:1.4.0'
     compile 'com.gluonhq:charm-glisten-connect-view:5.0.1'
-    compile 'com.gluonhq:charm-cloudlink-client:4.5.1'
+    compile 'com.gluonhq:charm-cloudlink-client:4.5.2'
     compile 'com.gluonhq:maps:1.0.2'
 }
 

--- a/DevoxxClientMobile/src/main/java/com/devoxx/views/cell/ConferenceCell.java
+++ b/DevoxxClientMobile/src/main/java/com/devoxx/views/cell/ConferenceCell.java
@@ -1,17 +1,40 @@
+/**
+ * Copyright (c) 2018, Gluon Software
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+ * following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse
+ *    or promote products derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 package com.devoxx.views.cell;
 
 import com.devoxx.DevoxxView;
 import com.devoxx.model.Conference;
 import com.devoxx.service.Service;
 import com.devoxx.util.DevoxxSettings;
+import com.devoxx.views.helper.ETagImageTask;
 import com.gluonhq.charm.down.Services;
 import com.gluonhq.charm.down.plugins.SettingsService;
-import com.gluonhq.charm.down.plugins.StorageService;
 import com.gluonhq.charm.glisten.application.MobileApplication;
 import com.gluonhq.charm.glisten.control.CharmListCell;
-import com.gluonhq.connect.provider.RestClient;
 import javafx.beans.binding.DoubleBinding;
-import javafx.concurrent.Task;
 import javafx.css.PseudoClass;
 import javafx.scene.control.Label;
 import javafx.scene.image.Image;
@@ -20,10 +43,8 @@ import javafx.scene.layout.BorderPane;
 import javafx.scene.layout.StackPane;
 import javafx.scene.layout.VBox;
 
-import java.io.*;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
-import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.logging.Level;
@@ -36,7 +57,7 @@ public class ConferenceCell extends CharmListCell<Conference> {
     private static final PseudoClass PSEUDO_CLASS_VOXXED = PseudoClass.getPseudoClass("voxxed");
     private static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern("MMMM dd, yyyy");
     
-    private static final ExecutorService executor = Executors.newCachedThreadPool();
+    private static final ExecutorService executor = Executors.newSingleThreadExecutor();
     
     private final Service service;
     private final Label name;
@@ -85,10 +106,13 @@ public class ConferenceCell extends CharmListCell<Conference> {
         getStyleClass().add("conference-cell"); 
     }
 
+    private ETagImageTask imageTask;
+
     @Override
     public void updateItem(Conference item, boolean empty) {
         super.updateItem(item, empty);
         
+        background.setImage(null);
         if (item != null && !empty) {
             eventType.setText(item.getEventType().name());
             
@@ -100,15 +124,22 @@ public class ConferenceCell extends CharmListCell<Conference> {
                         LocalDate.parse(item.getEndDate()).format(DATE_TIME_FORMATTER));
             }
 
-            final Task<InputStream> inputStreamTask = loadBackgroundImage(item);
-            inputStreamTask.setOnSucceeded(e -> {
-                Image image = new Image(inputStreamTask.getValue());
-                background.setImage(image);
-            });
-            inputStreamTask.exceptionProperty().addListener((o, ov, nv) -> {
-                LOG.log(Level.SEVERE, nv.getMessage());
-            });
-            executor.submit(inputStreamTask);
+            if (imageTask != null) {
+                imageTask.cancel();
+            }
+            // if (!item.getId().equals("51")) {
+                imageTask = new ETagImageTask("conference_" + item.getId(), item.getImageURL());
+                imageTask.setOnSucceeded(e -> {
+                    background.setImage(imageTask.getValue());
+                });
+                imageTask.exceptionProperty().addListener((o, ov, nv) -> {
+                    LOG.log(Level.SEVERE, nv.getMessage());
+                });
+                executor.submit(imageTask);
+                imageTask.image().ifPresent(background::setImage);
+            /*} else {
+                background.setImage(new Image(item.getImageURL(), true));
+            }*/
             
             background.fitWidthProperty().bind(widthProperty.subtract(2));
             
@@ -125,54 +156,6 @@ public class ConferenceCell extends CharmListCell<Conference> {
             setGraphic(root);
         } else {
             setGraphic(null);
-        }
-    }
-
-    private Task<InputStream> loadBackgroundImage(Conference conference) {
-
-        return new Task<InputStream>() {
-
-            @Override
-            protected InputStream call() throws Exception {
-                final String eventImageFileName = conference.getId() + "_event_background_image.jpeg";
-                final Optional<File> optionalRootDir = Services.get(StorageService.class).flatMap(StorageService::getPrivateStorage);
-                if (optionalRootDir.isPresent()) {
-                    final File rootDir = optionalRootDir.get();
-                    File eventImageFile = new File(rootDir, eventImageFileName);
-                    if (eventImageFile.exists()) {
-                        return new FileInputStream(eventImageFile);
-                    }
-                }
-                
-                // File not found on local device, download from internet
-                RestClient restClient = RestClient.create()
-                        .method("GET")
-                        .contentType("image/jpeg")
-                        .host(conference.getImageURL())
-                        .readTimeout(30000)
-                        .connectTimeout(60000);
-                final InputStream inputStream = restClient.createRestDataSource().getInputStream();
-                
-                // Write to file
-                if (optionalRootDir.isPresent()) {
-                    final File rootDir = optionalRootDir.get();
-                    File eventImageFile = new File(rootDir, eventImageFileName);
-                    writeToFile(inputStream, eventImageFile);
-                    return new FileInputStream(eventImageFile);
-                }
-                
-                // If no setting service is present, return the InputStream directly
-                return inputStream;
-            }
-        };
-    }
-
-    private void writeToFile(InputStream inputStream, File eventImageFile) throws IOException {
-        FileOutputStream writer = new FileOutputStream(eventImageFile);
-        byte[] buffer = new byte[2048];
-        int len;
-        while ((len = inputStream.read(buffer)) != -1) {
-            writer.write(buffer, 0, len);
         }
     }
 }

--- a/DevoxxClientMobile/src/main/java/com/devoxx/views/helper/ETagImageTask.java
+++ b/DevoxxClientMobile/src/main/java/com/devoxx/views/helper/ETagImageTask.java
@@ -1,0 +1,158 @@
+/**
+ * Copyright (c) 2018, Gluon Software
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+ * following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse
+ *    or promote products derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.devoxx.views.helper;
+
+import com.gluonhq.connect.provider.RestClient;
+import com.gluonhq.connect.source.FileDataSource;
+import com.gluonhq.connect.source.RestDataSource;
+import com.gluonhq.impl.cloudlink.client.PrivateStorage;
+import com.gluonhq.impl.cloudlink.client.data.function.CachingInputStream;
+import javafx.concurrent.Task;
+import javafx.scene.image.Image;
+
+import javax.json.Json;
+import javax.json.JsonObject;
+import javax.json.JsonReader;
+import javax.json.JsonWriter;
+import java.io.*;
+import java.util.List;
+import java.util.Optional;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+public class ETagImageTask extends Task<Image> {
+
+    private static final String DEVOXX_IMAGE = "_devoxx_image";
+    private static Logger LOGGER = Logger.getLogger(ETagImageTask.class.getName());
+
+    private final String imageFileName;
+    private final String url;
+    private Image image;
+
+    public ETagImageTask(String id, String url) {
+        this.imageFileName = id + DEVOXX_IMAGE + url.substring(url.lastIndexOf("."));
+        this.url = url;
+
+        try {
+            final FileDataSource imageDataSource = createCacheImageDataSource(imageFileName);
+            if (imageDataSource != null && imageDataSource.getFile().exists()) {
+                image = new Image(imageDataSource.getInputStream());
+            }
+        } catch (IOException e) {
+            // do nothing
+        }
+    }
+
+    public Optional<Image> image() {
+        return Optional.ofNullable(image);
+    }
+
+    @Override
+    protected Image call() throws Exception {
+        final FileDataSource eTagDataSource = createETagDataSource(imageFileName + ".etag");
+        String eTag = readFromETag(eTagDataSource);
+        RestClient client = createMediaRestClient(url, eTag);
+        updateProgress(0.1, 1.0);
+
+        final RestDataSource restDataSource = client.createRestDataSource();
+        final FileDataSource cacheImageDataSource = createCacheImageDataSource(imageFileName);
+        final InputStream inputStream = restDataSource.getInputStream();
+        if (inputStream == null) {
+            updateProgress(1.0, 1.0);
+            return null;
+        }
+
+        updateProgress(0.25, 1.0);
+
+        if (cacheImageDataSource != null &&
+                cacheImageDataSource.getFile().exists() &&
+                restDataSource.getResponseCode() == 304) {
+            updateProgress(1.0, 1.0);
+            return image != null ? image : new Image(cacheImageDataSource.getInputStream());
+
+        }
+        writeToETag(eTagDataSource, restDataSource);
+        if (cacheImageDataSource != null) {
+            updateProgress(1.0, 1.0);
+            try (CachingInputStream cis = new CachingInputStream(inputStream, cacheImageDataSource.getOutputStream())) {
+                return new Image(cis);
+            }
+        }
+        updateProgress(1.0, 1.0);
+        return new Image(inputStream);
+    }
+
+    private RestClient createMediaRestClient(String url, String eTag) {
+        return RestClient.create()
+                .method("GET")
+                .header("If-None-Match", eTag)
+                .host(url)
+                .readTimeout(30000)
+                .connectTimeout(60000);
+    }
+
+    private String readFromETag(FileDataSource eTagDataSource) {
+        if (eTagDataSource != null && eTagDataSource.getFile().exists()) {
+            try (JsonReader reader = Json.createReader(eTagDataSource.getInputStream())) {
+                JsonObject jsonObject = reader.readObject();
+                return jsonObject.getString("eTag");
+
+            } catch (IOException e) {
+                LOGGER.log(Level.FINE, "Could not read ETag file.", e);
+            }
+        }
+        return "";
+    }
+
+    private void writeToETag(FileDataSource eTagDataSource, RestDataSource restDataSource) {
+        final List<String> eTagString = restDataSource.getResponseHeaders().get("ETag");
+        if (eTagString != null && eTagString.size() > 0) {
+            try (JsonWriter writer = Json.createWriter(eTagDataSource.getOutputStream())) {
+                writer.write(Json.createObjectBuilder().add("eTag", eTagString.get(0)).build());
+            } catch (IOException e) {
+                LOGGER.log(Level.FINE, "Could not write to ETag file.", e);
+            }
+        }
+    }
+
+    private FileDataSource createETagDataSource(String name) {
+        File root = PrivateStorage.get();
+        if (root != null) {
+            File cache = new File(root, name);
+            return new FileDataSource(cache);
+        }
+        return null;
+    }
+
+    private FileDataSource createCacheImageDataSource(String mediaName) {
+        File root = PrivateStorage.get();
+        if (root != null) {
+            File cache = new File(root, mediaName);
+            return new FileDataSource(cache);
+        }
+        return null;
+    }
+}

--- a/DevoxxRemoteFunctions/src/main/java/com/gluonhq/devoxx/serverless/retrievesessions/SessionsRetriever.java
+++ b/DevoxxRemoteFunctions/src/main/java/com/gluonhq/devoxx/serverless/retrievesessions/SessionsRetriever.java
@@ -48,10 +48,6 @@ public class SessionsRetriever {
     private static final Client client = ClientBuilder.newClient();
 
     public String retrieve(String cfpEndpoint, String conferenceId) throws IOException {
-        if (cfpEndpoint.startsWith("http://")) {
-            cfpEndpoint = "https://" + cfpEndpoint.substring("http://".length());
-        }
-
         Response schedules = client.target(cfpEndpoint).path("conferences").path(conferenceId).path("schedules/")
                 .request().get();
         if (schedules.getStatus() == Response.Status.OK.getStatusCode()) {

--- a/DevoxxRemoteFunctions/src/main/java/com/gluonhq/devoxx/serverless/retrievesessions/SessionsRetriever.java
+++ b/DevoxxRemoteFunctions/src/main/java/com/gluonhq/devoxx/serverless/retrievesessions/SessionsRetriever.java
@@ -48,6 +48,10 @@ public class SessionsRetriever {
     private static final Client client = ClientBuilder.newClient();
 
     public String retrieve(String cfpEndpoint, String conferenceId) throws IOException {
+        if (cfpEndpoint.startsWith("http://")) {
+            cfpEndpoint = "https://" + cfpEndpoint.substring("http://".length());
+        }
+
         Response schedules = client.target(cfpEndpoint).path("conferences").path(conferenceId).path("schedules/")
                 .request().get();
         if (schedules.getStatus() == Response.Status.OK.getStatusCode()) {

--- a/DevoxxRemoteFunctions/src/main/java/com/gluonhq/devoxx/serverless/verifyaccount/AccountVerifier.java
+++ b/DevoxxRemoteFunctions/src/main/java/com/gluonhq/devoxx/serverless/verifyaccount/AccountVerifier.java
@@ -108,7 +108,9 @@ public class AccountVerifier {
         formDataMultiPart.field("password", password);
 
         Response accountVerification = buildClientRegularCfp().target(cfpEndpoint).path("account").path("credentials")
-                .request().post(Entity.entity(formDataMultiPart, MediaType.MULTIPART_FORM_DATA_TYPE));
+                .request()
+                .header("X-Gluon", System.getenv("DEVOXX_CFP_X_GLUON_HEADER"))
+                .post(Entity.entity(formDataMultiPart, MediaType.MULTIPART_FORM_DATA_TYPE));
         String response = accountVerification.readEntity(String.class);
         LOGGER.log(Level.INFO, "Account Verification Response: {0}", response);
         if (accountVerification.getStatus() == Response.Status.OK.getStatusCode()) {

--- a/DevoxxRemoteFunctions/src/main/java/com/gluonhq/devoxx/serverless/verifyaccount/AccountVerifier.java
+++ b/DevoxxRemoteFunctions/src/main/java/com/gluonhq/devoxx/serverless/verifyaccount/AccountVerifier.java
@@ -49,6 +49,10 @@ public class AccountVerifier {
     private static final Logger LOGGER = Logger.getLogger(AccountVerifier.class.getName());
 
     public String verify(String cfpEndpoint, String email, String password) throws IOException {
+        if (cfpEndpoint.startsWith("http://")) {
+            cfpEndpoint = "https://" + cfpEndpoint.substring("http://".length());
+        }
+
         if (cfpEndpoint.contains("cfp.devoxx.fr")) {
             return verifyDevoxxFr(email, password);
         } else {

--- a/DevoxxRemoteFunctions/src/main/java/com/gluonhq/devoxx/serverless/verifyaccount/AccountVerifier.java
+++ b/DevoxxRemoteFunctions/src/main/java/com/gluonhq/devoxx/serverless/verifyaccount/AccountVerifier.java
@@ -49,10 +49,6 @@ public class AccountVerifier {
     private static final Logger LOGGER = Logger.getLogger(AccountVerifier.class.getName());
 
     public String verify(String cfpEndpoint, String email, String password) throws IOException {
-        if (cfpEndpoint.startsWith("http://")) {
-            cfpEndpoint = "https://" + cfpEndpoint.substring("http://".length());
-        }
-
         if (cfpEndpoint.contains("cfp.devoxx.fr")) {
             return verifyDevoxxFr(email, password);
         } else {


### PR DESCRIPTION
This PR adds ETag validation for requests to the conference and exhibition map images.

When an ETag header is present, the image will be cached on the local file system, together with the ETag value. Each subsequent request will pass on the If-None-Match header and re-use the cached image if a 304 status code is returned. Otherwise the new value will be used and cached.