### PR TITLE
Add a conference loading layer

### DIFF
--- a/DevoxxClientCommon/src/main/java/com/devoxx/model/Conference.java
+++ b/DevoxxClientCommon/src/main/java/com/devoxx/model/Conference.java
@@ -33,6 +33,7 @@ import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -490,6 +491,19 @@ public class Conference {
 
     public void setSelected(boolean selected) {
         this.selected = selected;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Conference that = (Conference) o;
+        return Objects.equals(id, that.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
     }
 
     @Override

--- a/DevoxxClientCommon/src/main/java/com/devoxx/util/DevoxxSettings.java
+++ b/DevoxxClientCommon/src/main/java/com/devoxx/util/DevoxxSettings.java
@@ -109,6 +109,7 @@ public class DevoxxSettings {
     public static final String SKIP_FAV_DIALOG = "SKIP_FAV_DIALOG";
     public static final String SIGN_UP = "sign_up";
     public static final String SAVED_CONFERENCE_ID = "devoxx_cfp_id";
+    public static final String SAVED_CONFERENCE_NAME = "devoxx_cfp_name";
     public static final String SAVED_CONFERENCE_TYPE = "devoxx_cfp_type";
     public static final String SAVED_ACCOUNT_ID = "devoxx_cfp_account";
     public static final String BADGE_TYPE = "badge-type";

--- a/DevoxxClientMobile/src/main/java/com/devoxx/DevoxxApplication.java
+++ b/DevoxxClientMobile/src/main/java/com/devoxx/DevoxxApplication.java
@@ -28,6 +28,7 @@ package com.devoxx;
 import com.airhacks.afterburner.injection.Injector;
 import com.devoxx.model.Badge;
 import com.devoxx.model.BadgeType;
+import com.devoxx.model.Conference;
 import com.devoxx.model.Sponsor;
 import com.devoxx.model.SponsorBadge;
 import com.devoxx.service.DevoxxService;
@@ -37,6 +38,7 @@ import com.devoxx.views.DevoxxSplash;
 import com.devoxx.views.SessionsPresenter;
 import com.devoxx.views.helper.ConnectivityUtils;
 import com.devoxx.views.helper.SessionVisuals;
+import com.devoxx.views.layer.ConferenceLoadingLayer;
 import com.gluonhq.charm.down.Platform;
 import com.gluonhq.charm.down.Services;
 import com.gluonhq.charm.down.plugins.*;
@@ -130,9 +132,15 @@ public class DevoxxApplication extends MobileApplication {
 
         // Check if conference is set and switch to Sessions view
         Services.get(SettingsService.class).ifPresent(settingsService -> {
-            String configuredConference = settingsService.retrieve(DevoxxSettings.SAVED_CONFERENCE_ID);
-            if (configuredConference != null) {
-                DevoxxView.SESSIONS.switchView();
+            String conferenceId = settingsService.retrieve(DevoxxSettings.SAVED_CONFERENCE_ID);
+            String conferenceName = settingsService.retrieve(DevoxxSettings.SAVED_CONFERENCE_NAME);
+            String conferenceType = settingsService.retrieve(DevoxxSettings.SAVED_CONFERENCE_TYPE);
+            if (conferenceId != null && conferenceName != null && conferenceType != null) {
+                Conference conference = new Conference();
+                conference.setId(conferenceId);
+                conference.setName(conferenceName);
+                conference.setEventType(conferenceType);
+                ConferenceLoadingLayer.show(service, conference);
             }
         });
 

--- a/DevoxxClientMobile/src/main/java/com/devoxx/service/DevoxxService.java
+++ b/DevoxxClientMobile/src/main/java/com/devoxx/service/DevoxxService.java
@@ -32,6 +32,7 @@ import com.devoxx.util.DevoxxNotifications;
 import com.devoxx.util.DevoxxSettings;
 import com.devoxx.views.helper.Placeholder;
 import com.devoxx.views.helper.SessionVisuals.SessionListType;
+import com.devoxx.views.layer.ConferenceLoadingLayer;
 import com.gluonhq.charm.down.Services;
 import com.gluonhq.charm.down.plugins.RuntimeArgsService;
 import com.gluonhq.charm.down.plugins.SettingsService;
@@ -458,6 +459,7 @@ public class DevoxxService implements Service {
         sessionsList.setOnFailed(e -> {
             retrievingSessions.set(false);
             sessionsList.removeListener(sessionsListChangeListener);
+            ConferenceLoadingLayer.hide(getConference());
             LOG.log(Level.WARNING, String.format(REMOTE_FUNCTION_FAILED_MSG, "sessions"), e.getSource().getException());
         });
         sessionsList.setOnSucceeded(e -> {

--- a/DevoxxClientMobile/src/main/java/com/devoxx/service/DevoxxService.java
+++ b/DevoxxClientMobile/src/main/java/com/devoxx/service/DevoxxService.java
@@ -73,8 +73,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import static com.devoxx.util.DevoxxSettings.DAYS_PAST_END_DATE;
-import static com.devoxx.views.helper.Util.*;
+import static com.devoxx.views.helper.Util.safeStr;
 
 public class DevoxxService implements Service {
 
@@ -230,12 +229,6 @@ public class DevoxxService implements Service {
 
                 favorites.clear();
                 refreshFavorites();
-
-                if (isConferenceFromPast(nv)) {
-                    showPastConferenceMessage();
-                } else {
-                    hidePastConferenceMessage();
-                }
             }
         });
 
@@ -250,14 +243,6 @@ public class DevoxxService implements Service {
                 }
             }
         });
-    }
-
-    /**
-     * A conference is considered from past if
-     * {@link DevoxxSettings#DAYS_PAST_END_DATE} days have passed since its end date
-     */
-    private boolean isConferenceFromPast(Conference conference) {
-        return conference.getDaysUntilEnd() < -(DAYS_PAST_END_DATE);
     }
 
     @Override

--- a/DevoxxClientMobile/src/main/java/com/devoxx/views/SessionsPresenter.java
+++ b/DevoxxClientMobile/src/main/java/com/devoxx/views/SessionsPresenter.java
@@ -117,13 +117,22 @@ public class SessionsPresenter  extends GluonPresenter<DevoxxApplication> {
     private BottomNavigationButton favoriteButton;
 
     public void initialize() {
+
+        // Filter
+        final Button filterButton = createFilterButton();
+        filterSessionsView = new GluonView(FilterSessionsPresenter.class);
+        filterPresenter = (FilterSessionsPresenter) filterSessionsView.getPresenter();
+        filterPredicateProperty.bind(filterPresenter.searchPredicateProperty());
+        filterButton.pseudoClassStateChanged(PSEUDO_FILTER_ENABLED, filterPresenter.isFilterApplied());
+        filterPresenter.filterAppliedProperty().addListener((ov, oldValue, newValue) -> {
+            filterButton.pseudoClassStateChanged(PSEUDO_FILTER_ENABLED, newValue);
+        });
+
         createView();
         service.conferenceProperty().addListener((obs, ov, nv) -> {
             sessions.setBottom(null);
             createView();
         });
-
-        final Button filterButton = createFilterButton();
 
         sessions.setOnShowing(event -> {
             AppBar appBar = getApp().getAppBar();
@@ -148,14 +157,6 @@ public class SessionsPresenter  extends GluonPresenter<DevoxxApplication> {
             showRatingDialog();
         });
 
-        // Filter
-        filterSessionsView = new GluonView(FilterSessionsPresenter.class);
-        filterPresenter = (FilterSessionsPresenter) filterSessionsView.getPresenter();
-        filterPredicateProperty.bind(filterPresenter.searchPredicateProperty());
-        filterButton.pseudoClassStateChanged(PSEUDO_FILTER_ENABLED, filterPresenter.isFilterApplied());
-        filterPresenter.filterAppliedProperty().addListener((ov, oldValue, newValue) -> {
-            filterButton.pseudoClassStateChanged(PSEUDO_FILTER_ENABLED, newValue);
-        });
         MobileApplication.getInstance().addLayerFactory(DevoxxApplication.POPUP_FILTER_SESSIONS_MENU, () -> {
             if (filterPopup == null) {
                 filterPopup = new SidePopupView(filterSessionsView.getView(), Side.TOP, true);

--- a/DevoxxClientMobile/src/main/java/com/devoxx/views/cell/ConferenceCell.java
+++ b/DevoxxClientMobile/src/main/java/com/devoxx/views/cell/ConferenceCell.java
@@ -30,6 +30,7 @@ import com.devoxx.model.Conference;
 import com.devoxx.service.Service;
 import com.devoxx.util.DevoxxSettings;
 import com.devoxx.views.helper.ETagImageTask;
+import com.devoxx.views.layer.ConferenceLoadingLayer;
 import com.gluonhq.charm.down.Services;
 import com.gluonhq.charm.down.plugins.SettingsService;
 import com.gluonhq.charm.glisten.application.MobileApplication;
@@ -146,6 +147,7 @@ public class ConferenceCell extends CharmListCell<Conference> {
             
             content.setOnMouseReleased(e -> {
                 if (!item.equals(service.getConference())) {
+                    ConferenceLoadingLayer.show(service, item.getName());
                     service.retrieveConference(item.getId());
                     Services.get(SettingsService.class).ifPresent(settingsService -> {
                         settingsService.store(DevoxxSettings.SAVED_CONFERENCE_TYPE, item.getEventType().name());

--- a/DevoxxClientMobile/src/main/java/com/devoxx/views/cell/ConferenceCell.java
+++ b/DevoxxClientMobile/src/main/java/com/devoxx/views/cell/ConferenceCell.java
@@ -147,14 +147,16 @@ public class ConferenceCell extends CharmListCell<Conference> {
             
             content.setOnMouseReleased(e -> {
                 if (!item.equals(service.getConference())) {
-                    ConferenceLoadingLayer.show(service, item.getName());
+                    ConferenceLoadingLayer.show(service, item);
                     service.retrieveConference(item.getId());
                     Services.get(SettingsService.class).ifPresent(settingsService -> {
                         settingsService.store(DevoxxSettings.SAVED_CONFERENCE_TYPE, item.getEventType().name());
                         settingsService.store(DevoxxSettings.SAVED_CONFERENCE_ID, String.valueOf(item.getId()));
+                        settingsService.store(DevoxxSettings.SAVED_CONFERENCE_NAME, String.valueOf(item.getName()));
                     });
+                } else {
+                    DevoxxView.SESSIONS.switchView();
                 }
-                DevoxxView.SESSIONS.switchView();
             });
             setGraphic(root);
         } else {

--- a/DevoxxClientMobile/src/main/java/com/devoxx/views/helper/Util.java
+++ b/DevoxxClientMobile/src/main/java/com/devoxx/views/helper/Util.java
@@ -25,6 +25,7 @@
  */
 package com.devoxx.views.helper;
 
+import com.devoxx.model.Conference;
 import com.devoxx.model.Speaker;
 import com.devoxx.util.DevoxxBundle;
 import com.devoxx.util.ImageCache;
@@ -56,6 +57,8 @@ import javafx.util.Duration;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.function.Supplier;
+
+import static com.devoxx.util.DevoxxSettings.DAYS_PAST_END_DATE;
 
 public class Util {
 
@@ -206,6 +209,14 @@ public class Util {
 
     public static String safeStr(String s) {
         return s == null? "": s.trim();
+    }
+
+    /**
+     * A conference is considered from past if
+     * {@link DevoxxSettings#DAYS_PAST_END_DATE} days have passed since its end date
+     */
+    public static boolean isConferenceFromPast(Conference conference) {
+        return conference.getDaysUntilEnd() < -(DAYS_PAST_END_DATE);
     }
 
     public static void hidePastConferenceMessage() {

--- a/DevoxxClientMobile/src/main/java/com/devoxx/views/layer/ConferenceLoadingLayer.java
+++ b/DevoxxClientMobile/src/main/java/com/devoxx/views/layer/ConferenceLoadingLayer.java
@@ -1,6 +1,8 @@
 package com.devoxx.views.layer;
 
 import com.devoxx.service.Service;
+import com.gluonhq.charm.down.Services;
+import com.gluonhq.charm.down.plugins.DisplayService;
 import com.gluonhq.charm.glisten.application.GlassPane;
 import com.gluonhq.charm.glisten.application.MobileApplication;
 import com.gluonhq.charm.glisten.control.ProgressIndicator;
@@ -23,6 +25,7 @@ public class ConferenceLoadingLayer extends Layer {
     private final ProgressIndicator progressIndicator;
     private final Label conferenceLabel;
     private Region background;
+    private final DisplayService displayService;
 
     private ConferenceLoadingLayer(Service service, String conferenceName) {
 
@@ -57,6 +60,8 @@ public class ConferenceLoadingLayer extends Layer {
         });
         timeout.playFromStart();
         service.retrieveSessions().addListener(sessionsListener);
+
+        displayService = Services.get(DisplayService.class).orElse(null);
     }
     
     public static void show(Service service, String conferenceName) {
@@ -70,8 +75,11 @@ public class ConferenceLoadingLayer extends Layer {
         background.resizeRelocate(0, 0, glassPaneWidth, glassPaneHeight);
 
         double radius = Math.min(glassPaneWidth, glassPaneHeight) / 2 - 20;
+        if (displayService != null && displayService.isTablet()) {
+            radius = Math.min(glassPaneWidth, glassPaneHeight) / 4;
+        }
         progressIndicator.setRadius(radius);
-        progressIndicator.resizeRelocate(20, glassPaneHeight / 2 - radius, radius * 2, radius * 2);
+        progressIndicator.resizeRelocate(glassPaneWidth / 2 - radius, glassPaneHeight / 2 - radius, radius * 2, radius * 2);
 
         double labelWidth = Math.min(conferenceLabel.prefWidth(-1), radius - 10);
         double labelHeight = conferenceLabel.prefHeight(labelWidth);

--- a/DevoxxClientMobile/src/main/java/com/devoxx/views/layer/ConferenceLoadingLayer.java
+++ b/DevoxxClientMobile/src/main/java/com/devoxx/views/layer/ConferenceLoadingLayer.java
@@ -1,5 +1,7 @@
 package com.devoxx.views.layer;
 
+import com.devoxx.DevoxxView;
+import com.devoxx.model.Conference;
 import com.devoxx.service.Service;
 import com.gluonhq.charm.down.Services;
 import com.gluonhq.charm.down.plugins.DisplayService;
@@ -10,37 +12,42 @@ import com.gluonhq.charm.glisten.layout.Layer;
 import javafx.animation.PauseTransition;
 import javafx.beans.InvalidationListener;
 import javafx.beans.Observable;
+import javafx.css.PseudoClass;
 import javafx.scene.control.Label;
 import javafx.scene.layout.Region;
-import javafx.scene.text.Font;
-import javafx.scene.text.FontWeight;
-import javafx.scene.text.TextAlignment;
 import javafx.util.Duration;
 
+import static com.devoxx.views.helper.Util.hidePastConferenceMessage;
+import static com.devoxx.views.helper.Util.isConferenceFromPast;
+import static com.devoxx.views.helper.Util.showPastConferenceMessage;
+
 public class ConferenceLoadingLayer extends Layer {
-    
+
+    private static final PseudoClass PSEUDO_CLASS_VOXXED = PseudoClass.getPseudoClass("voxxed");
     private static Duration TIMEOUT = Duration.seconds(20);
 
+    private final Service service;
     private final GlassPane glassPane;
-    private final ProgressIndicator progressIndicator;
-    private final Label conferenceLabel;
-    private Region background;
     private final DisplayService displayService;
 
-    private ConferenceLoadingLayer(Service service, String conferenceName) {
+    private final Label conferenceLabel;
+    private final Region background;
+    private final ProgressIndicator progressIndicator;
 
+    private ConferenceLoadingLayer(Service service, Conference conference) {
+        this.service = service;
         this.glassPane = MobileApplication.getInstance().getGlassPane();
-        progressIndicator = new ProgressIndicator();
 
-        conferenceLabel = new Label(conferenceName);
-        conferenceLabel.setWrapText(true);
-        conferenceLabel.setTextAlignment(TextAlignment.CENTER);
-        conferenceLabel.setFont(Font.font(Font.getDefault().getFamily(), FontWeight.BOLD, 15));
+        progressIndicator = new ProgressIndicator();
+        progressIndicator.pseudoClassStateChanged(PSEUDO_CLASS_VOXXED, Conference.Type.VOXXED == conference.getEventType());
+
+        conferenceLabel = new Label(conference.getName());
 
         background = new Region();
-        background.setStyle("-fx-background-color: white;");
+        background.getStyleClass().add("background");
 
         setAutoHide(false);
+        getStyleClass().add("conf-layer");
         getChildren().addAll(background, progressIndicator, conferenceLabel);
 
         final PauseTransition timeout = new PauseTransition(TIMEOUT);
@@ -64,8 +71,19 @@ public class ConferenceLoadingLayer extends Layer {
         displayService = Services.get(DisplayService.class).orElse(null);
     }
     
-    public static void show(Service service, String conferenceName) {
-        new ConferenceLoadingLayer(service, conferenceName).show();
+    public static void show(Service service, Conference conference) {
+        new ConferenceLoadingLayer(service, conference).show();
+    }
+
+    @Override
+    public void hide() {
+        DevoxxView.SESSIONS.switchView();
+        if (isConferenceFromPast(service.getConference())) {
+            showPastConferenceMessage();
+        } else {
+            hidePastConferenceMessage();
+        }
+        super.hide();
     }
 
     @Override

--- a/DevoxxClientMobile/src/main/java/com/devoxx/views/layer/ConferenceLoadingLayer.java
+++ b/DevoxxClientMobile/src/main/java/com/devoxx/views/layer/ConferenceLoadingLayer.java
@@ -1,0 +1,82 @@
+package com.devoxx.views.layer;
+
+import com.devoxx.service.Service;
+import com.gluonhq.charm.glisten.application.GlassPane;
+import com.gluonhq.charm.glisten.application.MobileApplication;
+import com.gluonhq.charm.glisten.control.ProgressIndicator;
+import com.gluonhq.charm.glisten.layout.Layer;
+import javafx.animation.PauseTransition;
+import javafx.beans.InvalidationListener;
+import javafx.beans.Observable;
+import javafx.scene.control.Label;
+import javafx.scene.layout.Region;
+import javafx.scene.text.Font;
+import javafx.scene.text.FontWeight;
+import javafx.scene.text.TextAlignment;
+import javafx.util.Duration;
+
+public class ConferenceLoadingLayer extends Layer {
+    
+    private static Duration TIMEOUT = Duration.seconds(20);
+
+    private final GlassPane glassPane;
+    private final ProgressIndicator progressIndicator;
+    private final Label conferenceLabel;
+    private Region background;
+
+    private ConferenceLoadingLayer(Service service, String conferenceName) {
+
+        this.glassPane = MobileApplication.getInstance().getGlassPane();
+        progressIndicator = new ProgressIndicator();
+
+        conferenceLabel = new Label(conferenceName);
+        conferenceLabel.setWrapText(true);
+        conferenceLabel.setTextAlignment(TextAlignment.CENTER);
+        conferenceLabel.setFont(Font.font(Font.getDefault().getFamily(), FontWeight.BOLD, 15));
+
+        background = new Region();
+        background.setStyle("-fx-background-color: white;");
+
+        setAutoHide(false);
+        getChildren().addAll(background, progressIndicator, conferenceLabel);
+
+        final PauseTransition timeout = new PauseTransition(TIMEOUT);
+        final InvalidationListener sessionsListener = new InvalidationListener() {
+            @Override
+            public void invalidated(Observable o) {
+                if (service.retrieveSessions().size() > 0) {
+                    timeout.stop();
+                    ConferenceLoadingLayer.this.hide();
+                    service.retrieveSessions().removeListener(this);
+                }
+            }
+        };
+        timeout.setOnFinished(e -> {
+            service.retrieveSessions().removeListener(sessionsListener);
+            hide();
+        });
+        timeout.playFromStart();
+        service.retrieveSessions().addListener(sessionsListener);
+    }
+    
+    public static void show(Service service, String conferenceName) {
+        new ConferenceLoadingLayer(service, conferenceName).show();
+    }
+
+    @Override
+    public void layoutChildren() {
+        final double glassPaneWidth = snapSize(glassPane.getWidth());
+        final double glassPaneHeight = snapSize(glassPane.getHeight());
+        background.resizeRelocate(0, 0, glassPaneWidth, glassPaneHeight);
+
+        double radius = Math.min(glassPaneWidth, glassPaneHeight) / 2 - 20;
+        progressIndicator.setRadius(radius);
+        progressIndicator.resizeRelocate(20, glassPaneHeight / 2 - radius, radius * 2, radius * 2);
+
+        double labelWidth = Math.min(conferenceLabel.prefWidth(-1), radius - 10);
+        double labelHeight = conferenceLabel.prefHeight(labelWidth);
+        conferenceLabel.resizeRelocate(glassPaneWidth / 2 - labelWidth / 2, glassPaneHeight / 2 - labelHeight / 2, labelWidth, labelHeight);
+
+        super.layoutChildren();
+    }
+}

--- a/DevoxxClientMobile/src/main/java/com/devoxx/views/layer/ConferenceLoadingLayer.java
+++ b/DevoxxClientMobile/src/main/java/com/devoxx/views/layer/ConferenceLoadingLayer.java
@@ -1,3 +1,28 @@
+/*
+ * Copyright (c) 2018, Gluon Software
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+ * following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse
+ *    or promote products derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 package com.devoxx.views.layer;
 
 import com.devoxx.DevoxxView;
@@ -9,22 +34,21 @@ import com.gluonhq.charm.glisten.application.GlassPane;
 import com.gluonhq.charm.glisten.application.MobileApplication;
 import com.gluonhq.charm.glisten.control.ProgressIndicator;
 import com.gluonhq.charm.glisten.layout.Layer;
-import javafx.animation.PauseTransition;
 import javafx.beans.InvalidationListener;
-import javafx.beans.Observable;
 import javafx.css.PseudoClass;
 import javafx.scene.control.Label;
 import javafx.scene.layout.Region;
-import javafx.util.Duration;
 
-import static com.devoxx.views.helper.Util.hidePastConferenceMessage;
-import static com.devoxx.views.helper.Util.isConferenceFromPast;
-import static com.devoxx.views.helper.Util.showPastConferenceMessage;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import static com.devoxx.views.helper.Util.*;
 
 public class ConferenceLoadingLayer extends Layer {
 
     private static final PseudoClass PSEUDO_CLASS_VOXXED = PseudoClass.getPseudoClass("voxxed");
-    private static Duration TIMEOUT = Duration.seconds(20);
+    private static final Map<Conference, ConferenceLoadingLayer> map = new HashMap<>();
 
     private final Service service;
     private final GlassPane glassPane;
@@ -33,10 +57,12 @@ public class ConferenceLoadingLayer extends Layer {
     private final Label conferenceLabel;
     private final Region background;
     private final ProgressIndicator progressIndicator;
+    private final InvalidationListener sessionsListener;
 
     private ConferenceLoadingLayer(Service service, Conference conference) {
         this.service = service;
-        this.glassPane = MobileApplication.getInstance().getGlassPane();
+        glassPane = MobileApplication.getInstance().getGlassPane();
+        displayService = Services.get(DisplayService.class).orElse(null);
 
         progressIndicator = new ProgressIndicator();
         progressIndicator.pseudoClassStateChanged(PSEUDO_CLASS_VOXXED, Conference.Type.VOXXED == conference.getEventType());
@@ -50,33 +76,36 @@ public class ConferenceLoadingLayer extends Layer {
         getStyleClass().add("conf-layer");
         getChildren().addAll(background, progressIndicator, conferenceLabel);
 
-        final PauseTransition timeout = new PauseTransition(TIMEOUT);
-        final InvalidationListener sessionsListener = new InvalidationListener() {
-            @Override
-            public void invalidated(Observable o) {
-                if (service.retrieveSessions().size() > 0) {
-                    timeout.stop();
-                    ConferenceLoadingLayer.this.hide();
-                    service.retrieveSessions().removeListener(this);
-                }
+        // Listener helps for quick response in cases where data has been cached
+        sessionsListener = o -> {
+            if (service.retrieveSessions().size() > 0) {
+                hide();
             }
         };
-        timeout.setOnFinished(e -> {
-            service.retrieveSessions().removeListener(sessionsListener);
-            hide();
-        });
-        timeout.playFromStart();
-        service.retrieveSessions().addListener(sessionsListener);
-
-        displayService = Services.get(DisplayService.class).orElse(null);
     }
     
     public static void show(Service service, Conference conference) {
-        new ConferenceLoadingLayer(service, conference).show();
+        ConferenceLoadingLayer cll = map.get(conference);
+        if (cll == null) {
+            cll = new ConferenceLoadingLayer(service, conference);
+            map.put(conference, cll);
+        }
+        cll.show();
+    }
+
+    public static void hide(Conference conference) {
+        Optional.ofNullable(map.get(conference)).ifPresent(ConferenceLoadingLayer::hide);
+    }
+
+    @Override
+    public void show() {
+        service.retrieveSessions().addListener(sessionsListener);
+        super.show();
     }
 
     @Override
     public void hide() {
+        service.retrieveSessions().removeListener(sessionsListener);
         DevoxxView.SESSIONS.switchView();
         if (isConferenceFromPast(service.getConference())) {
             showPastConferenceMessage();

--- a/DevoxxClientMobile/src/main/resources/com/devoxx/common.css
+++ b/DevoxxClientMobile/src/main/resources/com/devoxx/common.css
@@ -66,6 +66,7 @@
     -fx-background-color: -primary-swatch-700;
 }
 
+/** Conference Selector **/
 .conf-selector-view {
     -fx-background-color: #202122;
 }
@@ -132,6 +133,26 @@
 .conf-selector.popup-view .label {
     -fx-font-size: 1.25em;
     -fx-padding: 1em 4em 1em 1em;
+}
+
+/** Conference Loader Layer **/
+.conf-layer > .label {
+    -fx-wrap-text: true;
+    -fx-text-alignment: center;
+    -fx-font-weight: bold;
+    -fx-font-size: 1.1em;
+}
+
+.conf-layer > .background {
+    -fx-background-color: white;
+}
+
+.conf-layer > .progress-indicator {
+    -fx-color: #DF9356;
+}
+
+.conf-layer > .progress-indicator:voxxed {
+    -fx-color: #65B3D8;
 }
 
 /** PastConference Message **/

--- a/DevoxxClientMobile/src/main/resources/com/devoxx/common_tablet.css
+++ b/DevoxxClientMobile/src/main/resources/com/devoxx/common_tablet.css
@@ -31,3 +31,8 @@
 .navigation-drawer > * > .scroll-pane > .viewport > * > .container > .item > .item-content > .text-box > .label {
     -fx-font-size: 1.1em;
 }
+
+/** Conference Loader Layer **/
+.conf-layer > .label {
+    -fx-font-size: 1.3em;
+}


### PR DESCRIPTION
This PR introduces a conference loading layer which is shown when a conference is selected by the user. The layer will hide itself either when loading of sessions is completed or timeout of 20 seconds has reached.

Fixes #135