### PR TITLE
issue-110: Keep aspect ratio of images, and clip them based on phone/…

### DIFF
--- a/DevoxxClientMobile/src/main/java/com/devoxx/views/cell/ConferenceCell.java
+++ b/DevoxxClientMobile/src/main/java/com/devoxx/views/cell/ConferenceCell.java
@@ -44,7 +44,6 @@ import javafx.scene.layout.VBox;
 
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
-import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.logging.Level;

--- a/DevoxxClientMobile/src/main/java/com/devoxx/views/cell/ConferenceCell.java
+++ b/DevoxxClientMobile/src/main/java/com/devoxx/views/cell/ConferenceCell.java
@@ -44,6 +44,7 @@ import javafx.scene.layout.VBox;
 
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
+import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.logging.Level;
@@ -78,6 +79,7 @@ public class ConferenceCell extends CharmListCell<Conference> {
     private final BorderPane content;
     private final StackPane root;
     private final double maxH;
+    private final Rectangle clip;
 
     public ConferenceCell(Service service) {
         this.service = service;
@@ -87,19 +89,14 @@ public class ConferenceCell extends CharmListCell<Conference> {
         
         eventType = new Label();
         eventType.getStyleClass().add("type");
-        eventType.textProperty().addListener((observable, oldValue, newValue) -> {
-            if (newValue.equals(Conference.Type.VOXXED.name())) {
-                pseudoClassStateChanged(PSEUDO_CLASS_VOXXED, true);
-            } else {
-                pseudoClassStateChanged(PSEUDO_CLASS_VOXXED, false);
-            }
-        });
         
         dateLabel = new Label();
         dateLabel.getStyleClass().add("date");
         
         background = new ImageView();
         background.setPreserveRatio(true);
+        clip = new Rectangle();
+        background.setClip(clip);
         MobileApplication.getInstance().getGlassPane().widthProperty().addListener((obs, ov, nv) -> fitImage());
         
         top = new VBox(eventType, name);
@@ -127,6 +124,11 @@ public class ConferenceCell extends CharmListCell<Conference> {
         background.setImage(null);
         if (item != null && !empty) {
             eventType.setText(item.getEventType().name());
+            if (item.getEventType().name().equals(Conference.Type.VOXXED.name())) {
+                pseudoClassStateChanged(PSEUDO_CLASS_VOXXED, true);
+            } else {
+                pseudoClassStateChanged(PSEUDO_CLASS_VOXXED, false);
+            }
             
             name.setText(item.getName());
             if (item.getFromDate().equals(item.getEndDate())) {
@@ -174,17 +176,18 @@ public class ConferenceCell extends CharmListCell<Conference> {
         Image image = background.getImage();
         if (image != null) {
             double factor = image.getHeight() / image.getWidth();
-            double maxW = MobileApplication.getInstance().getGlassPane().getWidth() - 30;
+            final double maxW = MobileApplication.getInstance().getGlassPane().getWidth() - 30;
             if (factor < maxH / maxW) {
                 background.setFitWidth(10000);
                 background.setFitHeight(maxH);
-                background.setClip(new Rectangle(0, 0, maxW, maxH));
+                clip.setY(0);
             } else {
                 background.setFitWidth(maxW);
                 background.setFitHeight(10000);
-                double realH = maxW * factor;
-                background.setClip(new Rectangle(0, (realH - maxH) / 2, maxW, maxH));
+                clip.setY((maxW * factor - maxH) / 2);
             }
+            clip.setWidth(maxW);
+            clip.setHeight(maxH);
         }
     }
 

--- a/DevoxxClientMobile/src/main/java/com/devoxx/views/cell/ConferenceCell.java
+++ b/DevoxxClientMobile/src/main/java/com/devoxx/views/cell/ConferenceCell.java
@@ -149,7 +149,10 @@ public class ConferenceCell extends CharmListCell<Conference> {
                 LOG.log(Level.SEVERE, nv.getMessage());
             });
             executor.submit(imageTask);
-            imageTask.image().ifPresent(background::setImage);
+            imageTask.image().ifPresent(image -> {
+                background.setImage(image);
+                fitImage();
+            });
 
             content.setOnMouseReleased(e -> {
                 if (!item.equals(service.getConference())) {


### PR DESCRIPTION
…tablet factor

The images on a tablet are clipped from the center.

This is how it looks like on:

Android phone

![Android phone](https://user-images.githubusercontent.com/2043230/46133576-1cfff780-c241-11e8-8ab9-cd0f86b3ef09.png)

Android tablet
![Android tablet](https://user-images.githubusercontent.com/2043230/46133541-12456280-c241-11e8-87c5-b7638b1f9b04.png)

iOS phone
![iOS phone](https://user-images.githubusercontent.com/2043230/46133645-520c4a00-c241-11e8-98ee-7edb2303f5d5.jpg)

iOS tablet
![iOS tablet](https://user-images.githubusercontent.com/2043230/46133565-1a050700-c241-11e8-9ee5-c71dd5dc0dca.jpg)