### PR TITLE
Create public storage directory if it doesn't exist

### DIFF
--- a/DevoxxClientMobile/src/main/java/com/devoxx/DevoxxApplication.java
+++ b/DevoxxClientMobile/src/main/java/com/devoxx/DevoxxApplication.java
@@ -241,6 +241,9 @@ public class DevoxxApplication extends MobileApplication {
             Services.get(ShareService.class).ifPresent(s -> {
                 File root = Services.get(StorageService.class).flatMap(storage -> storage.getPublicStorage("Documents")).orElse(null);
                 if (root != null) {
+                    if (!root.exists()) {
+                        root.mkdirs();
+                    }
                     File file = new File(root, "Devoxx" + DevoxxCountry.getConfShortName(service.getConference().getCountry()) + "-badges.csv");
                     if (file.exists()) {
                         file.delete();


### PR DESCRIPTION
This PR fixes share functionality in mobile where it used to fail when the Documents directory was not present.