### PR TITLE
Use a new RF to fetch all conferences

### DIFF
--- a/DevoxxClientMobile/src/main/java/com/devoxx/service/DevoxxService.java
+++ b/DevoxxClientMobile/src/main/java/com/devoxx/service/DevoxxService.java
@@ -316,8 +316,9 @@ public class DevoxxService implements Service {
 
     @Override
     public GluonObservableList<Conference> retrievePastConferences() {
-        RemoteFunctionList fnConferences = RemoteFunctionBuilder.create("pastConferences")
+        RemoteFunctionList fnConferences = RemoteFunctionBuilder.create("conferences")
                 .param("time", "past")
+                .param("type", "")
                 .list();
         final GluonObservableList<Conference> conferences = fnConferences.call(Conference.class);
         conferences.setOnFailed(e -> LOG.log(
@@ -329,7 +330,7 @@ public class DevoxxService implements Service {
     
     @Override
     public GluonObservableList<Conference> retrieveConferences() {
-        RemoteFunctionList fnConferences = RemoteFunctionBuilder.create("conferences")
+        RemoteFunctionList fnConferences = RemoteFunctionBuilder.create("allConferences")
                 .list();
         final GluonObservableList<Conference> conferences = fnConferences.call(new JsonIterableInputConverter<>(Conference.class));
         conferences.setOnFailed(e -> LOG.log(Level.WARNING,

--- a/DevoxxClientMobile/src/main/java/com/devoxx/views/ConfSelectorPresenter.java
+++ b/DevoxxClientMobile/src/main/java/com/devoxx/views/ConfSelectorPresenter.java
@@ -134,11 +134,11 @@ public class ConfSelectorPresenter extends GluonPresenter<DevoxxApplication> {
         menu.getItems().addAll(devoxx, voxxed, futureEvents, pastEvents);
         
         devoxx.setOnAction(e -> {
-            updateFutureEvent(Conference.Type.DEVOXX.name());
+            updateFutureEvent(Conference.Type.DEVOXX);
             STATUS_BAR.pseudoClassStateChanged(PSEUDO_CLASS_STATUS_VOXXED, false);
         });
         voxxed.setOnAction(e -> {
-            updateFutureEvent(Conference.Type.VOXXED.name());
+            updateFutureEvent(Conference.Type.VOXXED);
             STATUS_BAR.pseudoClassStateChanged(PSEUDO_CLASS_STATUS_VOXXED, true);
         });
         futureEvents.setOnAction(e -> {
@@ -158,11 +158,10 @@ public class ConfSelectorPresenter extends GluonPresenter<DevoxxApplication> {
         return menuPopupView;
     }
 
-    private void updateFutureEvent(String eventName) {
+    private void updateFutureEvent(Conference.Type eventType) {
         selector.setItems(filteredList);
         selector.setComparator(futureConferenceComparator);
-        if (eventName != null) {
-            Conference.Type eventType = Conference.Type.valueOf(eventName);
+        if (eventType != null) {
             header.setText(eventType.getDisplayName());
             filteredList.setPredicate(conference -> !isEmptyString(conference.getCfpURL()) && conference.getEventType() == eventType);
         } else {


### PR DESCRIPTION
This PR creates uses a new RF from GCL to fetch all the conferences so as to not interfere with current functionality.