### PR TITLE
#182 Make improvements to sponsor badge views

### DIFF
--- a/DevoxxClientCommon/src/main/java/com/devoxx/model/Sponsor.java
+++ b/DevoxxClientCommon/src/main/java/com/devoxx/model/Sponsor.java
@@ -62,7 +62,7 @@ public class Sponsor extends Searchable implements Mergeable<Sponsor> {
     }
 
     public String getSlug() {
-        return slug;
+        return slug == null ? name.toLowerCase().replaceAll(" ", "-") : slug;
     }
 
     public void setSlug(String slug) {

--- a/DevoxxClientMobile/src/main/java/com/devoxx/DevoxxView.java
+++ b/DevoxxClientMobile/src/main/java/com/devoxx/DevoxxView.java
@@ -48,7 +48,7 @@ public class DevoxxView {
     public static final AppView EXHIBITOR       = view( ExhibitorPresenter.class,      MaterialDesignIcon.PLACE);
     public static final AppView EXHIBITION_MAPS = view( ExhibitionMapsPresenter.class, MaterialDesignIcon.MAP,                SHOW_IN_DRAWER);
     public static final AppView EXHIBITION_MAP  = view( ExhibitionMapPresenter.class,  MaterialDesignIcon.MAP);
-    public static final AppView SPONSORS        = view( SponsorsPresenter.class,       MaterialDesignIcon.CARD_MEMBERSHIP);
+    public static final AppView SPONSORS        = view( SponsorsPresenter.class,       MaterialDesignIcon.CARD_MEMBERSHIP,    SKIP_VIEW_STACK);
     public static final AppView ATTENDEE_BADGE  = view( AttendeeBadgePresenter.class,  MaterialDesignIcon.CARD_MEMBERSHIP);
     public static final AppView SPONSOR_BADGE   = view( SponsorBadgePresenter.class,   MaterialDesignIcon.CARD_MEMBERSHIP);
     public static final AppView VENUE           = view( VenuePresenter.class,          MaterialDesignIcon.ACCESSIBILITY,      SHOW_IN_DRAWER);

--- a/DevoxxClientMobile/src/main/java/com/devoxx/views/SponsorBadgePresenter.java
+++ b/DevoxxClientMobile/src/main/java/com/devoxx/views/SponsorBadgePresenter.java
@@ -121,10 +121,10 @@ public class SponsorBadgePresenter extends GluonPresenter<DevoxxApplication> {
                     service.store(DevoxxSettings.BADGE_TYPE, BadgeType.SPONSOR.toString());
                     service.store(DevoxxSettings.BADGE_SPONSOR, sponsor.toCSV());
                 });
-                final Toast toast = new Toast(DevoxxBundle.getString("OTN.BADGES.LOGIN.SPONSOR", sponsor.getName()), Toast.LENGTH_LONG);
-                toast.show();
                 loadAuthenticatedView(sponsor);
                 password.clear();
+                final Toast toast = new Toast(DevoxxBundle.getString("OTN.BADGES.LOGIN.SPONSOR", sponsor.getName()), Toast.LENGTH_LONG);
+                toast.show();
             } else {
                 message.setText(DevoxxBundle.getString("OTN.SPONSOR.INCORRECT.PASSWORD"));
             } 
@@ -151,7 +151,7 @@ public class SponsorBadgePresenter extends GluonPresenter<DevoxxApplication> {
         appBar.setTitleText(DevoxxBundle.getString("OTN.SPONSOR.BADGES.FOR", sponsor.getName()));
         appBar.setNavIcon(getApp().getNavMenuButton());
         appBar.getActionItems().setAll(shareButton);
-        appBar.getMenuItems().addAll(getBadgeChangeMenuItem("Logout"));
+        appBar.getMenuItems().setAll(getBadgeChangeMenuItem("Logout"));
         
         shareButton.disableProperty().bind(sponsorBadges.itemsProperty().emptyProperty());
 


### PR DESCRIPTION
Contains the following changes:

* Sponsors view will skip view stack
* BadgesPresenter doesn't switch to SponsorView when Sponsor doesn't have all necessary fields
* In case, slug is null. `getSlug()` will return name in lowercase.
* When switching to sponsor badge view multiple times, logout menu item was duplicated. This has been fixed.