### PR TITLE
Disable leaderboard and remote rating data

### DIFF
--- a/DevoxxClientCommon/src/main/java/com/devoxx/model/Rating.java
+++ b/DevoxxClientCommon/src/main/java/com/devoxx/model/Rating.java
@@ -1,0 +1,30 @@
+package com.devoxx.model;
+
+import java.util.List;
+
+public class Rating {
+
+    private int rating;
+    private List<RatingData> data;
+
+    public Rating(int rating, List<RatingData> data) {
+        this.rating = rating;
+        this.data = data;
+    }
+
+    public int getRating() {
+        return rating;
+    }
+
+    public void setRating(int rating) {
+        this.rating = rating;
+    }
+
+    public List<RatingData> getData() {
+        return data;
+    }
+
+    public void setData(List<RatingData> data) {
+        this.data = data;
+    }
+}

--- a/DevoxxClientCommon/src/main/java/com/devoxx/model/Rating.java
+++ b/DevoxxClientCommon/src/main/java/com/devoxx/model/Rating.java
@@ -7,6 +7,8 @@ public class Rating {
     private int rating;
     private List<RatingData> data;
 
+    public Rating() {}
+
     public Rating(int rating, List<RatingData> data) {
         this.rating = rating;
         this.data = data;

--- a/DevoxxClientCommon/src/main/java/com/devoxx/model/RatingData.java
+++ b/DevoxxClientCommon/src/main/java/com/devoxx/model/RatingData.java
@@ -5,6 +5,8 @@ public class RatingData {
     private String text;
     private String imageUrl;
 
+    public RatingData() {}
+
     public RatingData(String text, String imageUrl) {
         this.text = text;
         this.imageUrl = imageUrl;

--- a/DevoxxClientCommon/src/main/java/com/devoxx/model/RatingData.java
+++ b/DevoxxClientCommon/src/main/java/com/devoxx/model/RatingData.java
@@ -1,0 +1,28 @@
+package com.devoxx.model;
+
+public class RatingData {
+
+    private String text;
+    private String imageUrl;
+
+    public RatingData(String text, String imageUrl) {
+        this.text = text;
+        this.imageUrl = imageUrl;
+    }
+
+    public String getText() {
+        return text;
+    }
+
+    public void setText(String text) {
+        this.text = text;
+    }
+
+    public String getImageUrl() {
+        return imageUrl;
+    }
+
+    public void setImageUrl(String imageUrl) {
+        this.imageUrl = imageUrl;
+    }
+}

--- a/DevoxxClientMobile/src/main/java/com/devoxx/DevoxxView.java
+++ b/DevoxxClientMobile/src/main/java/com/devoxx/DevoxxView.java
@@ -62,7 +62,7 @@ public class DevoxxView {
     public static final AppView FEEDBACK        = view( FeedbackPresenter.class,       MaterialDesignIcon.CREATE,             SKIP_VIEW_STACK);
     public static final AppView CONF_SELECTOR   = view( ConfSelectorPresenter.class,   MaterialDesignIcon.ANNOUNCEMENT,       SHOW_IN_DRAWER, HOME_VIEW, SKIP_VIEW_STACK);
     public static final AppView VOTE            = view( VotePresenter.class,           MaterialDesignIcon.THUMBS_UP_DOWN,     SKIP_VIEW_STACK);
-    public static final AppView LEADERBOARD     = view( LeaderboardPresenter.class,    MaterialDesignIcon.STARS, SHOW_IN_DRAWER);
+    // public static final AppView LEADERBOARD     = view( LeaderboardPresenter.class,    MaterialDesignIcon.STARS, SHOW_IN_DRAWER);
 
     private static AppView view(Class<? extends GluonPresenter<?>> presenterClass, MaterialDesignIcon menuIcon, AppView.Flag... flags ) {
         return REGISTRY.createView( name(presenterClass),

--- a/DevoxxClientMobile/src/main/java/com/devoxx/service/DevoxxService.java
+++ b/DevoxxClientMobile/src/main/java/com/devoxx/service/DevoxxService.java
@@ -806,6 +806,23 @@ public class DevoxxService implements Service {
     }
 
     @Override
+    public ObservableList<RatingData> retrieveVoteTexts(int rating) {
+        ObservableList<RatingData> ratingData = FXCollections.observableArrayList();
+        RemoteFunctionList fnTexts = RemoteFunctionBuilder.create("voteTexts").list();
+        GluonObservableList<Rating> voteTexts = fnTexts.call(Rating.class);
+        voteTexts.setOnSucceeded(e -> {
+            for (Rating voteText : voteTexts) {
+                if (voteText.getRating() == rating) {
+                    ratingData.setAll(voteText.getData());
+                    break;
+                }
+            }
+        });
+        voteTexts.setOnFailed(e -> LOG.log(Level.WARNING, String.format(REMOTE_FUNCTION_FAILED_MSG, "voteTexts"), e.getSource().getException()));
+        return ratingData;
+    }
+
+    @Override
     public GluonObservableObject<String> authenticateSponsor() {
         RemoteFunctionObject fnValidateSponsor = RemoteFunctionBuilder.create("validateSponsor").cachingEnabled(false).object();
         return fnValidateSponsor.call(String.class);

--- a/DevoxxClientMobile/src/main/java/com/devoxx/service/Service.java
+++ b/DevoxxClientMobile/src/main/java/com/devoxx/service/Service.java
@@ -295,4 +295,9 @@ public interface Service {
      * @return Location of the selected conference
      */
     GluonObservableObject<Location> retrieveLocation();
+
+    /**
+     * Fetches a map of vote texts for each rating
+     */
+    ObservableList<RatingData> retrieveVoteTexts(int rating);
 }

--- a/DevoxxClientMobile/src/main/java/com/devoxx/views/LeaderboardPresenter.java
+++ b/DevoxxClientMobile/src/main/java/com/devoxx/views/LeaderboardPresenter.java
@@ -49,7 +49,7 @@ public class LeaderboardPresenter extends GluonPresenter<DevoxxApplication> {
 
         leaderboard.setOnShowing(event -> {
             AppBar appBar = getApp().getAppBar();
-            appBar.setTitleText(DevoxxView.LEADERBOARD.getTitle());
+            // appBar.setTitleText(DevoxxView.LEADERBOARD.getTitle());
             appBar.setNavIcon(getApp().getNavMenuButton());
         });
 

--- a/DevoxxClientMobile/src/main/java/com/devoxx/views/VotePresenter.java
+++ b/DevoxxClientMobile/src/main/java/com/devoxx/views/VotePresenter.java
@@ -66,7 +66,7 @@ public class VotePresenter extends GluonPresenter<DevoxxApplication> {
     @FXML private Label ratingLabel;
     @FXML private Rating rating;
     @FXML private Label compliment;
-    @FXML private ListView<com.devoxx.model.RatingData> comments;
+    @FXML private ListView<RatingData> comments;
     @FXML private TextArea feedback;
 
     @Inject private Service service;
@@ -98,40 +98,15 @@ public class VotePresenter extends GluonPresenter<DevoxxApplication> {
             rating.requestFocus();
         });
 
+        updateRating((int) rating.getRating());
+
         rating.ratingProperty().addListener((o, ov, nv) -> {
             comments.scrollTo(0);
-            int rating = nv.intValue();
-            switch (rating) {
-                case 5:
-                    ratingLabel.setText(bundle.getString("OTN.VOTE.EXCELLENT"));
-                    compliment.setText(bundle.getString("OTN.VOTE.COMPLIMENT"));
-                    comments.setItems(service.retrieveVoteTexts(5));
-                    break;
-                case 4:
-                    ratingLabel.setText(bundle.getString("OTN.VOTE.VERY.GOOD"));
-                    compliment.setText(bundle.getString("OTN.VOTE.COMPLIMENT"));
-                    comments.setItems(service.retrieveVoteTexts(4));
-                    break;
-                case 3:
-                    ratingLabel.setText(bundle.getString("OTN.VOTE.GOOD"));
-                    compliment.setText(bundle.getString("OTN.VOTE.COMPLIMENT"));
-                    comments.setItems(service.retrieveVoteTexts(3));
-                    break;
-                case 2:
-                    ratingLabel.setText(bundle.getString("OTN.VOTE.FAIR"));
-                    compliment.setText(bundle.getString("OTN.VOTE.COMPLIMENT"));
-                    comments.setItems(service.retrieveVoteTexts(2));
-                    break;
-                case 1:
-                    ratingLabel.setText(bundle.getString("OTN.VOTE.POOR"));
-                    compliment.setText(bundle.getString("OTN.VOTE.IMPROVEMENT"));
-                    comments.setItems(service.retrieveVoteTexts(1));
-                    break;
-            }
+            updateRating(nv.intValue());
         });
 
         comments.getSelectionModel().setSelectionMode(SelectionMode.SINGLE);
-        comments.setCellFactory(param -> new UnselectListCell<com.devoxx.model.RatingData>() {
+        comments.setCellFactory(param -> new UnselectListCell<RatingData>() {
 
             @Override
             protected void updateItem(RatingData item, boolean empty) {
@@ -187,6 +162,35 @@ public class VotePresenter extends GluonPresenter<DevoxxApplication> {
         return vote;
     }
 
+    private void updateRating(int rating) {
+        switch (rating) {
+            case 5:
+                ratingLabel.setText(bundle.getString("OTN.VOTE.EXCELLENT"));
+                compliment.setText(bundle.getString("OTN.VOTE.COMPLIMENT"));
+                comments.setItems(service.retrieveVoteTexts(5));
+                break;
+            case 4:
+                ratingLabel.setText(bundle.getString("OTN.VOTE.VERY.GOOD"));
+                compliment.setText(bundle.getString("OTN.VOTE.COMPLIMENT"));
+                comments.setItems(service.retrieveVoteTexts(4));
+                break;
+            case 3:
+                ratingLabel.setText(bundle.getString("OTN.VOTE.GOOD"));
+                compliment.setText(bundle.getString("OTN.VOTE.COMPLIMENT"));
+                comments.setItems(service.retrieveVoteTexts(3));
+                break;
+            case 2:
+                ratingLabel.setText(bundle.getString("OTN.VOTE.FAIR"));
+                compliment.setText(bundle.getString("OTN.VOTE.IMPROVEMENT"));
+                comments.setItems(service.retrieveVoteTexts(2));
+                break;
+            case 1:
+                ratingLabel.setText(bundle.getString("OTN.VOTE.POOR"));
+                compliment.setText(bundle.getString("OTN.VOTE.IMPROVEMENT"));
+                comments.setItems(service.retrieveVoteTexts(1));
+                break;
+        }
+    }
 
     private class UnselectListCell<T> extends ListCell<T> {
 

--- a/DevoxxClientMobile/src/main/resources/com/devoxx/views/vote.properties
+++ b/DevoxxClientMobile/src/main/resources/com/devoxx/views/vote.properties
@@ -28,5 +28,7 @@ OTN.VOTE.PROMPT_TEXT=Provide speaker feedback
 OTN.VOTE.COMPLIMENT=Give a compliment
 OTN.VOTE.IMPROVEMENT=What can be improved?
 OTN.VOTE.EXCELLENT=Excellent
+OTN.VOTE.VERY.GOOD=Very Good
 OTN.VOTE.GOOD=Good
+OTN.VOTE.FAIR=Fair
 OTN.VOTE.POOR=Poor

--- a/DevoxxClientMobile/src/main/resources/com/devoxx/views/vote_fr.properties
+++ b/DevoxxClientMobile/src/main/resources/com/devoxx/views/vote_fr.properties
@@ -28,5 +28,7 @@ OTN.VOTE.PROMPT_TEXT=Provide speaker feedback
 OTN.VOTE.COMPLIMENT=Give a compliment
 OTN.VOTE.IMPROVEMENT=What can be improved?
 OTN.VOTE.EXCELLENT=Excellent
+OTN.VOTE.VERY.GOOD=Very Good
 OTN.VOTE.GOOD=Good
+OTN.VOTE.FAIR=Fair
 OTN.VOTE.POOR=Poor


### PR DESCRIPTION
Rating image and text are fetched from GCL RF (currently with mock data)