### PR TITLE
Assign sponsor badge list once data fetch is complete

### DIFF
--- a/DevoxxClientMobile/src/main/java/com/devoxx/service/DevoxxService.java
+++ b/DevoxxClientMobile/src/main/java/com/devoxx/service/DevoxxService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2018 Gluon Software
+ * Copyright (c) 2016, 2019 Gluon Software
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
@@ -54,8 +54,6 @@ import com.gluonhq.connect.GluonObservableObject;
 import com.gluonhq.connect.converter.JsonInputConverter;
 import com.gluonhq.connect.converter.JsonIterableInputConverter;
 import com.gluonhq.connect.provider.DataProvider;
-import javafx.beans.Observable;
-import javafx.beans.binding.Bindings;
 import javafx.beans.property.*;
 import javafx.collections.FXCollections;
 import javafx.collections.ListChangeListener;
@@ -151,7 +149,7 @@ public class DevoxxService implements Service {
     private ObservableList<Session> favoredSessions;
     private ObservableList<Note> notes;
     private ObservableList<Badge> badges;
-    private ObservableList<SponsorBadge> sponsorBadges;
+    private GluonObservableList<SponsorBadge> sponsorBadges;
 
     private GluonObservableObject<Favorites> allFavorites;
     private ListChangeListener<Session> internalFavoredSessionsListener = null;
@@ -350,7 +348,7 @@ public class DevoxxService implements Service {
                 e.getSource().getException()));
         return conferences;
     }
-    
+
     @Override
     public GluonObservableList<Conference> retrieveConferences() {
         RemoteFunctionList fnConferences = RemoteFunctionBuilder.create("allConferences")
@@ -383,7 +381,7 @@ public class DevoxxService implements Service {
             });
             conference.setOnFailed(e -> LOG.log(Level.WARNING, String.format(REMOTE_FUNCTION_FAILED_MSG, "conference"), e.getSource().getException()));
         }
-        
+
         return conference;
     }
 
@@ -519,7 +517,7 @@ public class DevoxxService implements Service {
             retrievingSpeakers.set(false);
             LOG.log(Level.WARNING, String.format(REMOTE_FUNCTION_FAILED_MSG, "speakers"), e.getSource().getException());
         });
-        speakersList.setOnSucceeded(e -> { 
+        speakersList.setOnSucceeded(e -> {
             speakers.setAll(speakersList);
             retrievingSpeakers.set(false);
         });
@@ -782,7 +780,7 @@ public class DevoxxService implements Service {
     }
 
     @Override
-    public ObservableList<SponsorBadge> retrieveSponsorBadges(Sponsor sponsor) {
+    public GluonObservableList<SponsorBadge> retrieveSponsorBadges(Sponsor sponsor) {
         
         if (sponsorBadges == null) {
             sponsorBadges = internalRetrieveSponsorBadges(sponsor);
@@ -888,7 +886,7 @@ public class DevoxxService implements Service {
 
     @Override
     public void refreshFavorites() {
-        if (getConference() != null && DevoxxSettings.conferenceHasFavoriteCount(getConference()) && 
+        if (getConference() != null && DevoxxSettings.conferenceHasFavoriteCount(getConference()) &&
                 (allFavorites.getState() == ConnectState.SUCCEEDED || allFavorites.getState() == ConnectState.FAILED)) {
             RemoteFunctionObject fnAllFavorites = RemoteFunctionBuilder.create("allFavorites")
                     .param("0", getCfpURL())
@@ -911,7 +909,7 @@ public class DevoxxService implements Service {
             });
         }
     }
-    
+
     @Override
     public User getAuthenticatedUser() {
         return authenticationClient.getAuthenticatedUser();
@@ -948,11 +946,9 @@ public class DevoxxService implements Service {
     }
 
     private GluonObservableList<SponsorBadge> internalRetrieveSponsorBadges(Sponsor sponsor) {
-        GluonObservableList<SponsorBadge> localSponsorBadges = DataProvider.retrieveList(localDataClient.createListDataReader(getConference().getId() + "_" + sponsor.getSlug() + "_sponsor_badges_" +
+        return DataProvider.retrieveList(localDataClient.createListDataReader(getConference().getId() + "_" + sponsor.getSlug() + "_sponsor_badges_" +
                 Services.get(DeviceService.class).map(DeviceService::getUuid).orElse(System.getProperty("user.name")),
                 SponsorBadge.class, SyncFlag.LIST_WRITE_THROUGH, SyncFlag.OBJECT_WRITE_THROUGH));
-
-        return localSponsorBadges;
     }
 
     private void loadCfpAccount(User user, Runnable successRunnable) {

--- a/DevoxxClientMobile/src/main/java/com/devoxx/service/DevoxxService.java
+++ b/DevoxxClientMobile/src/main/java/com/devoxx/service/DevoxxService.java
@@ -946,9 +946,13 @@ public class DevoxxService implements Service {
     }
 
     private GluonObservableList<SponsorBadge> internalRetrieveSponsorBadges(Sponsor sponsor) {
-        return DataProvider.retrieveList(localDataClient.createListDataReader(getConference().getId() + "_" + sponsor.getSlug() + "_sponsor_badges_" +
+        GluonObservableList<SponsorBadge> localSponsorBadges = DataProvider.retrieveList(localDataClient.createListDataReader(getConference().getId() + "_" + sponsor.getSlug() + "_sponsor_badges_" +
                 Services.get(DeviceService.class).map(DeviceService::getUuid).orElse(System.getProperty("user.name")),
                 SponsorBadge.class, SyncFlag.LIST_WRITE_THROUGH, SyncFlag.OBJECT_WRITE_THROUGH));
+        localSponsorBadges.setOnFailed(ex -> {
+            LOG.log(Level.SEVERE, "Loading of badges for sponsor " + sponsor.getName() + " failed..", ex);
+        });
+        return localSponsorBadges;
     }
 
     private void loadCfpAccount(User user, Runnable successRunnable) {

--- a/DevoxxClientMobile/src/main/java/com/devoxx/service/Service.java
+++ b/DevoxxClientMobile/src/main/java/com/devoxx/service/Service.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2018 Gluon Software
+ * Copyright (c) 2016, 2019 Gluon Software
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
@@ -233,7 +233,7 @@ public interface Service {
      * @throws IllegalStateException when no user is currently authenticated
      * @param sponsor The sponsor for which badges are to be retrieved
      */
-    ObservableList<SponsorBadge> retrieveSponsorBadges(Sponsor sponsor);
+    GluonObservableList<SponsorBadge> retrieveSponsorBadges(Sponsor sponsor);
 
     /**
      * Logs out the currently logged in sponsor

--- a/DevoxxClientMobile/src/main/java/com/devoxx/views/SponsorBadgePresenter.java
+++ b/DevoxxClientMobile/src/main/java/com/devoxx/views/SponsorBadgePresenter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2018 Gluon Software
+ * Copyright (c) 2016, 2019 Gluon Software
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
@@ -47,6 +47,7 @@ import com.gluonhq.charm.glisten.control.CharmListView;
 import com.gluonhq.charm.glisten.control.FloatingActionButton;
 import com.gluonhq.charm.glisten.control.Toast;
 import com.gluonhq.charm.glisten.mvc.View;
+import com.gluonhq.connect.GluonObservableList;
 import javafx.collections.ObservableList;
 import javafx.collections.transformation.FilteredList;
 import javafx.fxml.FXML;
@@ -96,12 +97,15 @@ public class SponsorBadgePresenter extends GluonPresenter<DevoxxApplication> {
     }
 
     private void loadSponsorBadges(Sponsor sponsor) {
-        final ObservableList<SponsorBadge> badges = service.retrieveSponsorBadges(sponsor);
-        final FilteredList<SponsorBadge> filteredBadges = new FilteredList<>(badges, badge -> {
-            return badge != null && badge.getSponsor() != null && badge.getSponsor().equals(sponsor);
+        CharmListView<SponsorBadge, String> sponsorBadges = new CharmListView<>();
+        final GluonObservableList<SponsorBadge> badges = service.retrieveSponsorBadges(sponsor);
+        badges.setOnSucceeded(e -> {
+            final FilteredList<SponsorBadge> filteredBadges = new FilteredList<>(badges, badge -> {
+                return badge != null && badge.getSponsor() != null && badge.getSponsor().equals(sponsor);
+            });
+            sponsorBadges.setItems(filteredBadges);
         });
 
-        CharmListView<SponsorBadge, String> sponsorBadges = new CharmListView<>(filteredBadges);
         sponsorBadges.setPlaceholder(new Placeholder(EMPTY_LIST_MESSAGE, DevoxxView.SPONSOR_BADGE.getMenuIcon()));
         sponsorBadges.setCellFactory(param -> new BadgeCell<>());
         sponsorView.setCenter(sponsorBadges);


### PR DESCRIPTION
This helps fix NPE caused by the list getting assigned to the CLV before the data list has finished initialization.