### PR TITLE
#241 AudienceLevel should support the new data format

### DIFF
--- a/DevoxxClientCommon/src/main/java/com/devoxx/model/AudienceLevel.java
+++ b/DevoxxClientCommon/src/main/java/com/devoxx/model/AudienceLevel.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2019, Gluon Software
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+ * following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse
+ *    or promote products derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.devoxx.model;
+
+import com.devoxx.util.DevoxxBundle;
+
+public enum AudienceLevel {
+    BEGINNER     ("OTN.SESSION.AUDIENCE_LEVEL.BEGINNER"),
+    INTERMEDIATE ("OTN.SESSION.AUDIENCE_LEVEL.INTERMEDIATE"),
+    ADVANCED     ("OTN.SESSION.AUDIENCE_LEVEL.ADVANCED"),
+    EXPERT       ("OTN.SESSION.AUDIENCE_LEVEL.EXPERT");
+
+    private String resourceName;
+
+    AudienceLevel(String resourceName) {
+        this.resourceName = resourceName;
+    }
+
+    public String getText() {
+        return DevoxxBundle.getString(resourceName);
+    }
+}

--- a/DevoxxClientCommon/src/main/java/com/devoxx/model/AudienceLevel.java
+++ b/DevoxxClientCommon/src/main/java/com/devoxx/model/AudienceLevel.java
@@ -27,6 +27,8 @@ package com.devoxx.model;
 
 import com.devoxx.util.DevoxxBundle;
 
+import java.util.Arrays;
+
 public enum AudienceLevel {
     BEGINNER     ("OTN.SESSION.AUDIENCE_LEVEL.BEGINNER"),
     INTERMEDIATE ("OTN.SESSION.AUDIENCE_LEVEL.INTERMEDIATE"),
@@ -39,6 +41,23 @@ public enum AudienceLevel {
         this.resourceName = resourceName;
     }
 
+    /**
+     * Checks if a string can be mapped to any of the values in {@link AudienceLevel}.
+     * @param audienceLevel string to test
+     * @return True if the string matches one of the values, else false.
+     */
+    public static boolean contains(String audienceLevel) {
+        try {
+            return Arrays.asList(AudienceLevel.values()).contains(AudienceLevel.valueOf(audienceLevel));
+        } catch (IllegalArgumentException e) {
+            return false;
+        }
+    }
+
+    /**
+     * Returns the text to be displayed for an {@link AudienceLevel}.
+     * @return Text to be displayed for an {@link AudienceLevel}.
+     */
     public String getText() {
         return DevoxxBundle.getString(resourceName);
     }

--- a/DevoxxClientCommon/src/main/resources/com/devoxx/devoxx.properties
+++ b/DevoxxClientCommon/src/main/resources/com/devoxx/devoxx.properties
@@ -124,6 +124,7 @@ OTN.SESSION.VOTE_TIMING=Voting is enabled once a session starts.\nIt closes 12 h
 OTN.SESSION.NO_SPEAKERS=There are no speakers available for this session yet
 OTN.SESSION.AUDIENCE_LEVEL.BEGINNER=Open to all level of audience, beginner or novice
 OTN.SESSION.AUDIENCE_LEVEL.INTERMEDIATE=For intermediate audience
+OTN.SESSION.AUDIENCE_LEVEL.ADVANCED=For advanced audience
 OTN.SESSION.AUDIENCE_LEVEL.EXPERT=For expert and senior
 
 OTN.CONTENT_CATALOG.ALL_SESSIONS.PLACEHOLDER_MESSAGE=This view shows a list of available sessions.\nPlease check back later.

--- a/DevoxxClientCommon/src/main/resources/com/devoxx/devoxx_fr.properties
+++ b/DevoxxClientCommon/src/main/resources/com/devoxx/devoxx_fr.properties
@@ -128,6 +128,7 @@ OTN.SESSION.NO_SPEAKERS=Il n'y a pas encore d'orateurs annonc\u00e9s pour cette 
 # TODO: Translate to French
 OTN.SESSION.AUDIENCE_LEVEL.BEGINNER=Open to all level of audience, beginner or novice
 OTN.SESSION.AUDIENCE_LEVEL.INTERMEDIATE=For intermediate audience
+OTN.SESSION.AUDIENCE_LEVEL.ADVANCED=For advanced audience
 OTN.SESSION.AUDIENCE_LEVEL.EXPERT=For expert and senior
 
 OTN.CONTENT_CATALOG.ALL_SESSIONS.PLACEHOLDER_MESSAGE=Cette vue affiche la liste des sessions et des pr\u00e9sentations, lorsque l'agenda est publi\u00e9.\nMerci de revenir plus tard.

--- a/DevoxxClientMobile/src/main/java/com/devoxx/views/SessionPresenter.java
+++ b/DevoxxClientMobile/src/main/java/com/devoxx/views/SessionPresenter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2018 Gluon Software
+ * Copyright (c) 2016, 2019 Gluon Software
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
@@ -28,6 +28,7 @@ package com.devoxx.views;
 import com.devoxx.DevoxxApplication;
 import com.devoxx.DevoxxView;
 import com.devoxx.control.DataLabel;
+import com.devoxx.model.AudienceLevel;
 import com.devoxx.model.Link;
 import com.devoxx.model.Session;
 import com.devoxx.model.Speaker;
@@ -365,13 +366,7 @@ public class SessionPresenter extends GluonPresenter<DevoxxApplication> {
     }
 
     private Label fetchLabelForAudienceLevel(String audienceLevel) {
-        if (audienceLevel.equalsIgnoreCase("L1")) {
-            return new Label(DevoxxBundle.getString("OTN.SESSION.AUDIENCE_LEVEL.BEGINNER"));
-        } else if (audienceLevel.equalsIgnoreCase("L2")) {
-            return new Label(DevoxxBundle.getString("OTN.SESSION.AUDIENCE_LEVEL.INTERMEDIATE"));
-        } else {
-            return new Label(DevoxxBundle.getString("OTN.SESSION.AUDIENCE_LEVEL.EXPERT"));
-        }
+        return new Label(AudienceLevel.valueOf(audienceLevel).getText());
     }
 
     private Label createTag(String tagText) {

--- a/DevoxxClientMobile/src/main/java/com/devoxx/views/SessionPresenter.java
+++ b/DevoxxClientMobile/src/main/java/com/devoxx/views/SessionPresenter.java
@@ -337,10 +337,11 @@ public class SessionPresenter extends GluonPresenter<DevoxxApplication> {
         vbox.getStyleClass().add("session-info");
 
         // Check for audience level
-        if (session.getTalk().getAudienceLevel() != null) {
-            Label audienceLevel = fetchLabelForAudienceLevel(session.getTalk().getAudienceLevel());
-            audienceLevel.getStyleClass().add("audience-level");
-            vbox.getChildren().add(audienceLevel);
+        final String audienceLevel = session.getTalk().getAudienceLevel();
+        if (audienceLevel != null && AudienceLevel.contains(audienceLevel)) {
+            Label audienceLevelLabel = fetchLabelForAudienceLevel(audienceLevel);
+            audienceLevelLabel.getStyleClass().add("audience-level");
+            vbox.getChildren().add(audienceLevelLabel);
         }
         if (DevoxxSettings.conferenceHasMultipleLanguages(service.getConference())) {
             vbox.getChildren().add(flag(session));


### PR DESCRIPTION
Audience level is returned as BEGINNER, INTERMEDIATE, ADVANCED and EXPERT instead of L1, L2 and L3.

This PR adjusts the client according to the data returned.