### PR TITLE
Add option to sync sponsor badges

### DIFF
--- a/DevoxxClientCommon/src/main/java/com/devoxx/model/SponsorBadge.java
+++ b/DevoxxClientCommon/src/main/java/com/devoxx/model/SponsorBadge.java
@@ -25,10 +25,14 @@
  */
 package com.devoxx.model;
 
+import javafx.beans.Observable;
+import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.LongProperty;
 import javafx.beans.property.ObjectProperty;
+import javafx.beans.property.SimpleBooleanProperty;
 import javafx.beans.property.SimpleLongProperty;
 import javafx.beans.property.SimpleObjectProperty;
+import javafx.util.Callback;
 
 import java.sql.Timestamp;
 import java.text.SimpleDateFormat;
@@ -79,6 +83,18 @@ public class SponsorBadge extends Badge {
     public final void setDateTime(long value) {
         dateTime.set(value);
     }
+    
+    // syncProperty
+    private final BooleanProperty sync = new SimpleBooleanProperty(this, "sync", false);
+    public final BooleanProperty syncProperty() {
+       return sync;
+    }
+    public final boolean isSync() {
+       return sync.get();
+    }
+    public final void setSync(boolean value) {
+        sync.set(value);
+    }
 
     @Override
     public boolean contains(String keyword) {
@@ -103,7 +119,8 @@ public class SponsorBadge extends Badge {
         SponsorBadge that = (SponsorBadge) o;
         return Objects.equals(getBadgeId(), that.getBadgeId()) &&
                 Objects.equals(getSponsor(), that.getSponsor()) &&
-                Objects.equals(getDateTime(), that.getDateTime());
+                Objects.equals(getDateTime(), that.getDateTime()) &&
+                Objects.equals(isSync(), that.isSync());
     }
 
     @Override
@@ -119,5 +136,11 @@ public class SponsorBadge extends Badge {
             csv.append(",").append(safeStr(DATE_TIME_FORMATTER.format(new Timestamp(getDateTime()))));
         }
         return csv.toString();
+    }
+
+    public static Callback<SponsorBadge, Observable[]> extractor() {
+        return param -> new Observable[] {
+                param.syncProperty()
+        };
     }
 }

--- a/DevoxxClientCommon/src/main/resources/com/devoxx/devoxx.properties
+++ b/DevoxxClientCommon/src/main/resources/com/devoxx/devoxx.properties
@@ -159,6 +159,7 @@ OTN.VISUALS.IS_ABOUT_TO_START={0} is about to start
 OTN.VISUALS.CAST_YOUR_VOTE_ON=Cast your vote on {0}
 OTN.VISUALS.HELP_US_IMPROVE_DEVOXX=Help us improve Devoxx
 OTN.VISUALS.CONNECTION_FAILED=Connection failed!
+OTN.VISUALS.NO_INTERNET=No internet connectivity!
 OTN.VISUALS.SESSION_MARKED_AS_FAVORITE=Session marked as favorite!
 OTN.VISUALS.SESSION_UNFAVORITED=Session unfavorited!
 OTN.VISUALS.SESSION.FAVORITE_DIALOG.MSG=Add a session to your favorites with
@@ -167,6 +168,7 @@ OTN.VISUALS.SESSION.FAVORITE_DIALOG.MSG_INTRO=You can favorite multiple sessions
 OTN.SPONSOR.INCORRECT.PASSWORD=Incorrect Password
 OTN.SPONSOR.VERIFICATION.FAILED=Verification failed
 OTN.SPONSOR.BADGES.FOR=Badges for {0}
+OTN.SPONSOR.BADGES.SYNC=Syncing badges...
 OTN.SPONSOR.LOGOUT_DIALOG.CONTENT=Do you really want to log out as sponsor?
 
 OTN.FILTER.TABDAY=Day

--- a/DevoxxClientCommon/src/main/resources/com/devoxx/devoxx_fr.properties
+++ b/DevoxxClientCommon/src/main/resources/com/devoxx/devoxx_fr.properties
@@ -161,6 +161,8 @@ OTN.VISUALS.FORMAT.ONELINE=Day {0} \u00b7 {1}-{2} \u00b7 {3}
 OTN.VISUALS.IS_ABOUT_TO_START={0} va bient\u00f4t commencer
 OTN.VISUALS.CAST_YOUR_VOTE_ON=Merci de donner votre vote {0}
 OTN.VISUALS.CONNECTION_FAILED=Probl\u00e8me de connexion.
+#TODO: Translate to French
+OTN.VISUALS.NO_INTERNET=No internet connectivity!
 OTN.VISUALS.SESSION_MARKED_AS_FAVORITE=Session marqu\u00e9e comme Favorite.
 OTN.VISUALS.SESSION_UNFAVORITED=Session retir\u00e9e des Favoris.
 #TODO: Translate to French
@@ -172,6 +174,7 @@ OTN.VISUALS.SESSION.FAVORITE_DIALOG.MSG_INTRO=You can favorite multiple sessions
 OTN.SPONSOR.INCORRECT.PASSWORD=Incorrect Password
 OTN.SPONSOR.VERIFICATION.FAILED=Verification failed
 OTN.SPONSOR.BADGES.FOR=Badges for {0}
+OTN.SPONSOR.BADGES.SYNC=Syncing badges...
 OTN.SPONSOR.LOGOUT_DIALOG.CONTENT=Do you really want to log out as sponsor?
 
 OTN.FILTER.TABDAY=Jour

--- a/DevoxxClientMobile/src/main/java/com/devoxx/DevoxxDrawerPresenter.java
+++ b/DevoxxClientMobile/src/main/java/com/devoxx/DevoxxDrawerPresenter.java
@@ -129,7 +129,7 @@ public class DevoxxDrawerPresenter extends GluonPresenter<DevoxxApplication> {
 
     private void checkAndAddBadgesItem(Conference conference) {
         if (conference == null) return;
-        if (conference.isMyBadgeActive()) {
+        if (conference.isMyBadgeActive() || DevoxxSettings.BADGE_TESTS) {
             for (Node item : drawer.getItems()) {
                 if (((NavigationDrawer.Item) item).getTitle().equals(DevoxxBundle.getString("OTN.VIEW.NOTES"))) {
                     final int index = drawer.getItems().indexOf(item) + 1;

--- a/DevoxxClientMobile/src/main/java/com/devoxx/service/DevoxxService.java
+++ b/DevoxxClientMobile/src/main/java/com/devoxx/service/DevoxxService.java
@@ -1298,15 +1298,17 @@ public class DevoxxService implements Service {
 
     private void retrySaveSponsorBadge(SponsorBadge sponsorBadge) {
         Services.get(ConnectivityService.class).ifPresent(service -> {
-            service.connectedProperty().addListener(new ChangeListener<Boolean>() {
-                @Override
-                public void changed(ObservableValue<? extends Boolean> o, Boolean ov, Boolean nv) {
-                    if (nv) {
-                        saveSponsorBadge(sponsorBadge);
+            if (!service.isConnected()) {
+                service.connectedProperty().addListener(new ChangeListener<Boolean>() {
+                    @Override
+                    public void changed(ObservableValue<? extends Boolean> o, Boolean ov, Boolean nv) {
+                        if (nv) {
+                            saveSponsorBadge(sponsorBadge);
+                        }
+                        service.connectedProperty().removeListener(this);
                     }
-                    service.connectedProperty().removeListener(this);
-                }
-            });
+                });
+            }
         });
     }
 }

--- a/DevoxxClientMobile/src/main/java/com/devoxx/views/cell/BadgeCell.java
+++ b/DevoxxClientMobile/src/main/java/com/devoxx/views/cell/BadgeCell.java
@@ -36,9 +36,10 @@ import com.devoxx.model.Badge;
 import com.devoxx.views.BadgePresenter;
 
 public class BadgeCell<T extends Badge> extends CharmListCell<T> {
+
     private static final int MAX_TEXT_SIZE = 100;
 
-    private final ListTile tile;
+    protected final ListTile tile;
 
     public BadgeCell() {
         tile = new ListTile();

--- a/DevoxxClientMobile/src/main/java/com/devoxx/views/cell/SponsorBadgeCell.java
+++ b/DevoxxClientMobile/src/main/java/com/devoxx/views/cell/SponsorBadgeCell.java
@@ -32,25 +32,23 @@ import javafx.scene.layout.AnchorPane;
 import javafx.scene.layout.StackPane;
 
 public class SponsorBadgeCell extends BadgeCell<SponsorBadge> {
+
+    private final AnchorPane anchorPane;
     
     public SponsorBadgeCell() {
+        final Node graphic = MaterialDesignIcon.SYNC_PROBLEM.graphic();
+        anchorPane = new AnchorPane(graphic);
+        anchorPane.getStyleClass().add("sync-box");
+        AnchorPane.setTopAnchor(graphic, 2.0);
+        AnchorPane.setRightAnchor(graphic, 2.0);
+        final StackPane secondaryGraphic = new StackPane(anchorPane, MaterialDesignIcon.CHEVRON_RIGHT.graphic());
+        tile.setSecondaryGraphic(secondaryGraphic);
         getStyleClass().add("sponsor-badge-cell");
     }
 
     @Override
     public void updateItem(SponsorBadge badge, boolean empty) {
         super.updateItem(badge, empty);
-
-        final Node graphic = MaterialDesignIcon.SYNC_PROBLEM.graphic();
-        final AnchorPane anchorPane = new AnchorPane(graphic);
-        anchorPane.getStyleClass().add("sync-box");
-        AnchorPane.setTopAnchor(graphic, 2.0);
-        AnchorPane.setRightAnchor(graphic, 2.0);
-        if (badge.isSync()) {
-            anchorPane.setVisible(false);
-        }
-
-        final StackPane secondaryGraphic = new StackPane(anchorPane, MaterialDesignIcon.CHEVRON_RIGHT.graphic());
-        tile.setSecondaryGraphic(secondaryGraphic);
+        anchorPane.setVisible(!badge.isSync());
     }
 }

--- a/DevoxxClientMobile/src/main/java/com/devoxx/views/cell/SponsorBadgeCell.java
+++ b/DevoxxClientMobile/src/main/java/com/devoxx/views/cell/SponsorBadgeCell.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2019, Gluon Software
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+ * following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse
+ *    or promote products derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.devoxx.views.cell;
+
+import com.devoxx.model.SponsorBadge;
+import com.gluonhq.charm.glisten.visual.MaterialDesignIcon;
+import javafx.scene.Node;
+import javafx.scene.layout.AnchorPane;
+import javafx.scene.layout.StackPane;
+
+public class SponsorBadgeCell extends BadgeCell<SponsorBadge> {
+    
+    public SponsorBadgeCell() {
+        getStyleClass().add("sponsor-badge-cell");
+    }
+
+    @Override
+    public void updateItem(SponsorBadge badge, boolean empty) {
+        super.updateItem(badge, empty);
+
+        final Node graphic = MaterialDesignIcon.SYNC_PROBLEM.graphic();
+        final AnchorPane anchorPane = new AnchorPane(graphic);
+        anchorPane.getStyleClass().add("sync-box");
+        AnchorPane.setTopAnchor(graphic, 2.0);
+        AnchorPane.setRightAnchor(graphic, 2.0);
+        if (badge.isSync()) {
+            anchorPane.setVisible(false);
+        }
+
+        final StackPane secondaryGraphic = new StackPane(anchorPane, MaterialDesignIcon.CHEVRON_RIGHT.graphic());
+        tile.setSecondaryGraphic(secondaryGraphic);
+    }
+}

--- a/DevoxxClientMobile/src/main/resources/com/devoxx/common.css
+++ b/DevoxxClientMobile/src/main/resources/com/devoxx/common.css
@@ -1468,3 +1468,8 @@
 .authenticate-view .container > .links {
     -fx-padding: 0.5em;
 }
+
+/* SponsorBadge Cell */
+.sponsor-badge-cell .sync-box > .icon-text {
+    -fx-font-size: 0.80em;
+}


### PR DESCRIPTION
Once the badges are scanned, a new sync option is displayed on the badge to show is a badge is yet to be synced with the backend.

If during the scan, the device fails to send the the badge to the backend, a listener is attached to the connectivity service so as to automatically sync the badge once the connectivity is back.

A sync button is also added to the SponsorBadges view to enable to enable a sponsor to manually sync all pending badges.