### PR TITLE
Fix device check to load sans style

### DIFF
--- a/DevoxxClientMobile/src/main/java/com/devoxx/DevoxxApplication.java
+++ b/DevoxxClientMobile/src/main/java/com/devoxx/DevoxxApplication.java
@@ -138,7 +138,7 @@ public class DevoxxApplication extends MobileApplication {
                 .map(s -> {
                     if (Platform.isAndroid() && s.getModel() != null) {
                         for (String device : DevoxxSettings.DEVICES_WITH_SANS_CSS) {
-                            if (s.getModel().toLowerCase(Locale.ROOT).startsWith(device)) {
+                            if (s.getModel().toLowerCase(Locale.ROOT).contains(device)) {
                                 return "_sans";
                             }
                         }


### PR DESCRIPTION
`DeviceService#getModel` returns:

```
Build.MODEL + " ("+ Build.MANUFACTURER + ")"
```

Therefore, we need to switch the check from `startsWith` to `contains`.