### PR TITLE
sync property should be updated whenever details change

### DIFF
--- a/DevoxxClientMobile/src/main/java/com/devoxx/views/BadgePresenter.java
+++ b/DevoxxClientMobile/src/main/java/com/devoxx/views/BadgePresenter.java
@@ -80,6 +80,9 @@ public class BadgePresenter extends GluonPresenter<DevoxxApplication> {
     private ChangeListener<String> detailsChangeListener = (observable, oldValue, newValue) -> {
         if (newValue != null && !newValue.isEmpty()) {
             textChanged = true;
+            if (badge instanceof SponsorBadge) {
+                ((SponsorBadge) badge).setSync(false);
+            }
         }
     };
 


### PR DESCRIPTION
Sync property is set to false whenever the badge scanner edits the details property triggering  re-sync or the badge with the back-end.