### PR TITLE
#251 Background color should show sync status

### DIFF
--- a/DevoxxClientMobile/src/main/java/com/devoxx/views/SponsorBadgePresenter.java
+++ b/DevoxxClientMobile/src/main/java/com/devoxx/views/SponsorBadgePresenter.java
@@ -37,6 +37,7 @@ import com.devoxx.util.DevoxxSettings;
 import com.devoxx.views.cell.SponsorBadgeCell;
 import com.devoxx.views.helper.Placeholder;
 import com.devoxx.views.helper.Util;
+import com.gluonhq.charm.down.Platform;
 import com.gluonhq.charm.down.Services;
 import com.gluonhq.charm.down.plugins.BarcodeScanService;
 import com.gluonhq.charm.down.plugins.ConnectivityService;
@@ -177,20 +178,33 @@ public class SponsorBadgePresenter extends GluonPresenter<DevoxxApplication> {
     }
 
     private void syncSponsorBadges() {
-        Services.get(ConnectivityService.class).ifPresent(connectivityService -> {
-            final Toast toast = new Toast();
-            if (connectivityService.isConnected()) {
-                toast.setMessage(DevoxxBundle.getString("OTN.SPONSOR.BADGES.SYNC"));
-                toast.show();
-                for (SponsorBadge sponsorBadge : service.retrieveSponsorBadges(sponsor)) {
-                    if (!sponsorBadge.isSync()) {
-                        service.saveSponsorBadge(sponsorBadge);
-                    }
+        if (Platform.isDesktop()) {
+            sync();
+        } else {
+            Services.get(ConnectivityService.class).ifPresent(connectivityService -> {
+                if (connectivityService.isConnected()) {
+                    sync();
+                } else {
+                    showSyncFailureMessage();
                 }
-            } else {
-                toast.setMessage(DevoxxBundle.getString("OTN.VISUALS.NO_INTERNET"));
-                toast.show();
+            });
+        }
+    }
+
+    private void showSyncFailureMessage() {
+        final Toast toast = new Toast();
+        toast.setMessage(DevoxxBundle.getString("OTN.VISUALS.NO_INTERNET"));
+        toast.show();
+    }
+
+    private void sync() {
+        final Toast toast = new Toast();
+        toast.setMessage(DevoxxBundle.getString("OTN.SPONSOR.BADGES.SYNC"));
+        toast.show();
+        for (SponsorBadge sponsorBadge : service.retrieveSponsorBadges(sponsor)) {
+            if (!sponsorBadge.isSync()) {
+                service.saveSponsorBadge(sponsorBadge);
             }
-        });
+        }
     }
 }

--- a/DevoxxClientMobile/src/main/java/com/devoxx/views/cell/SponsorBadgeCell.java
+++ b/DevoxxClientMobile/src/main/java/com/devoxx/views/cell/SponsorBadgeCell.java
@@ -26,29 +26,19 @@
 package com.devoxx.views.cell;
 
 import com.devoxx.model.SponsorBadge;
-import com.gluonhq.charm.glisten.visual.MaterialDesignIcon;
-import javafx.scene.Node;
-import javafx.scene.layout.AnchorPane;
-import javafx.scene.layout.StackPane;
+import javafx.css.PseudoClass;
 
 public class SponsorBadgeCell extends BadgeCell<SponsorBadge> {
 
-    private final AnchorPane anchorPane;
+    private final PseudoClass PSEUDO_CLASS_SYNC = PseudoClass.getPseudoClass("sync");
     
     public SponsorBadgeCell() {
-        final Node graphic = MaterialDesignIcon.SYNC_PROBLEM.graphic();
-        anchorPane = new AnchorPane(graphic);
-        anchorPane.getStyleClass().add("sync-box");
-        AnchorPane.setTopAnchor(graphic, 2.0);
-        AnchorPane.setRightAnchor(graphic, 2.0);
-        final StackPane secondaryGraphic = new StackPane(anchorPane, MaterialDesignIcon.CHEVRON_RIGHT.graphic());
-        tile.setSecondaryGraphic(secondaryGraphic);
         getStyleClass().add("sponsor-badge-cell");
     }
 
     @Override
     public void updateItem(SponsorBadge badge, boolean empty) {
         super.updateItem(badge, empty);
-        anchorPane.setVisible(!badge.isSync());
+        pseudoClassStateChanged(PSEUDO_CLASS_SYNC, !badge.isSync());
     }
 }

--- a/DevoxxClientMobile/src/main/resources/com/devoxx/common.css
+++ b/DevoxxClientMobile/src/main/resources/com/devoxx/common.css
@@ -1473,3 +1473,7 @@
 .sponsor-badge-cell .sync-box > .icon-text {
     -fx-font-size: 0.80em;
 }
+
+.sponsor-badge-cell:sync {
+    -fx-background-color: derive(#ffd9e0, 40%);
+}


### PR DESCRIPTION
Replace not-sync icon with cell background color for showing badges that haven't been synced with the server yet.