### PR TITLE
#265 Show Alert message when conference RF fails

### DIFF
--- a/DevoxxClientCommon/src/main/resources/com/devoxx/devoxx.properties
+++ b/DevoxxClientCommon/src/main/resources/com/devoxx/devoxx.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2016, 2018 Gluon Software
+# Copyright (c) 2016, 2019, Gluon Software
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
@@ -66,6 +66,7 @@ OTN.BUTTON.VOTE=Vote
 OTN.FILTER.BUTTON.RESET=RESET
 
 OTN.DIALOG.DONT_SHOW_AGAIN=Don't show again
+OTN.DIALOG.CONF_ISSUE=Unable to load "%s".\nPlease try some other conference.
 
 OTN.VOTEPANE.DELIVERY=Delivery:
 OTN.VOTEPANE.CONTENT=Content:

--- a/DevoxxClientCommon/src/main/resources/com/devoxx/devoxx_fr.properties
+++ b/DevoxxClientCommon/src/main/resources/com/devoxx/devoxx_fr.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2016, 2018 Gluon Software
+# Copyright (c) 2016, 2019, Gluon Software
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
@@ -67,6 +67,8 @@ OTN.BUTTON.VOTE=Voter
 OTN.FILTER.BUTTON.RESET=ANNULER
 
 OTN.DIALOG.DONT_SHOW_AGAIN=Ne plus montrer
+# TODO: Translate to French
+OTN.DIALOG.CONF_ISSUE=Unable to load "%s".\nPlease try some other conference.
 
 OTN.VOTEPANE.DELIVERY=Qualit\u00e9 de la pr\u00e9sentation:
 OTN.VOTEPANE.CONTENT=Contenu pr\u00e9sent\u00e9:

--- a/DevoxxClientMobile/src/main/java/com/devoxx/DevoxxApplication.java
+++ b/DevoxxClientMobile/src/main/java/com/devoxx/DevoxxApplication.java
@@ -119,20 +119,10 @@ public class DevoxxApplication extends MobileApplication {
     public void postInit(Scene scene) {
 
         // Check if conference is set and switch to Sessions view
-        Services.get(SettingsService.class).ifPresent(settingsService -> {
-            String conferenceId = settingsService.retrieve(DevoxxSettings.SAVED_CONFERENCE_ID);
-            String conferenceCfpURL = settingsService.retrieve(DevoxxSettings.SAVED_CONFERENCE_CFP_URL);
-            String conferenceName = settingsService.retrieve(DevoxxSettings.SAVED_CONFERENCE_NAME);
-            String conferenceType = settingsService.retrieve(DevoxxSettings.SAVED_CONFERENCE_TYPE);
-            if (conferenceId != null && conferenceName != null && conferenceType != null) {
-                Conference conference = new Conference();
-                conference.setId(conferenceId);
-                conference.setCfpURL(conferenceCfpURL);
-                conference.setName(conferenceName);
-                conference.setEventType(conferenceType);
-                ConferenceLoadingLayer.show(service, conference);
-            }
-        });
+        final Conference conference = service.createConferenceFromLocalStorage();
+        if (conference.getId() != null && conference.getName() != null && conference.getEventType() != null) {
+            ConferenceLoadingLayer.show(service, conference);
+        }
 
         String deviceFactorSuffix = Services.get(DeviceService.class)
                 .map(s -> {

--- a/DevoxxClientMobile/src/main/java/com/devoxx/service/DevoxxService.java
+++ b/DevoxxClientMobile/src/main/java/com/devoxx/service/DevoxxService.java
@@ -258,15 +258,15 @@ public class DevoxxService implements Service {
         });
 
         Services.get(SettingsService.class).ifPresent(settingsService -> {
-            String configuredConferenceId = settingsService.retrieve(DevoxxSettings.SAVED_CONFERENCE_ID);
-            String configuredConferenceCfpURL = settingsService.retrieve(DevoxxSettings.SAVED_CONFERENCE_CFP_URL);
+            String configuredConferenceId = settingsService.retrieve(SAVED_CONFERENCE_ID);
+            String configuredConferenceCfpURL = settingsService.retrieve(SAVED_CONFERENCE_CFP_URL);
             if (configuredConferenceId != null) {
                 if (isNumber(configuredConferenceId)) {
                     retrieveConference(configuredConferenceId, configuredConferenceCfpURL);
                 } else {
                     LOG.log(Level.WARNING, "Found old conference id format, removing it");
                     clearCfpAccount();
-                    settingsService.remove(DevoxxSettings.SAVED_CONFERENCE_ID);
+                    settingsService.remove(SAVED_CONFERENCE_ID);
                 }
             }
 
@@ -428,9 +428,28 @@ public class DevoxxService implements Service {
                     setConference(conference.get());
                 }
                 LOG.log(Level.WARNING, String.format(REMOTE_FUNCTION_FAILED_MSG, "conference"), e.getSource().getException());
+                switchToConfSelectorAndShowAlert();
             });
         }
 
+        return conference;
+    }
+
+    @Override
+    public Conference createConferenceFromLocalStorage() {
+        Conference conference = new Conference();
+        Services.get(SettingsService.class).ifPresent(settingsService -> {
+            String conferenceId = settingsService.retrieve(DevoxxSettings.SAVED_CONFERENCE_ID);
+            String conferenceCfpURL = settingsService.retrieve(DevoxxSettings.SAVED_CONFERENCE_CFP_URL);
+            String conferenceName = settingsService.retrieve(DevoxxSettings.SAVED_CONFERENCE_NAME);
+            String conferenceType = settingsService.retrieve(DevoxxSettings.SAVED_CONFERENCE_TYPE);
+            if (conferenceId != null && conferenceCfpURL != null) {
+                conference.setId(conferenceId);
+                conference.setCfpURL(conferenceCfpURL);
+                conference.setName(conferenceName);
+                conference.setEventType(conferenceType);
+            }
+        });
         return conference;
     }
 
@@ -1335,6 +1354,25 @@ public class DevoxxService implements Service {
                     }
                 });
             }
+        });
+    }
+
+    private void switchToConfSelectorAndShowAlert() {
+        final Conference conferenceDetails = createConferenceFromLocalStorage();
+        ConferenceLoadingLayer.hide(conferenceDetails);
+        DevoxxView.CONF_SELECTOR.switchView();
+        Alert alert = new Alert(javafx.scene.control.Alert.AlertType.WARNING);
+        alert.setContentText(String.format(DevoxxBundle.getString("OTN.DIALOG.CONF_ISSUE"), conferenceDetails.getName()));
+        alert.setOnCloseRequest(cr -> clearConferenceDetails());
+        alert.showAndWait();
+    }
+
+    private void clearConferenceDetails() {
+        Services.get(SettingsService.class).ifPresent(settingsService -> {
+            settingsService.remove(SAVED_CONFERENCE_ID);
+            settingsService.remove(SAVED_CONFERENCE_CFP_URL);
+            settingsService.remove(SAVED_CONFERENCE_NAME);
+            settingsService.remove(SAVED_CONFERENCE_TYPE);
         });
     }
 }

--- a/DevoxxClientMobile/src/main/java/com/devoxx/service/Service.java
+++ b/DevoxxClientMobile/src/main/java/com/devoxx/service/Service.java
@@ -91,6 +91,12 @@ public interface Service {
      */
     Conference getConference();
 
+    /**
+     * Creates and returns a conference object from private storage
+     * @return Conference information from private storage
+     */
+    Conference createConferenceFromLocalStorage();
+
     ReadOnlyObjectProperty<Conference> conferenceProperty();
 
     /**

--- a/DevoxxClientMobile/src/main/java/com/devoxx/views/cell/ConferenceCell.java
+++ b/DevoxxClientMobile/src/main/java/com/devoxx/views/cell/ConferenceCell.java
@@ -176,13 +176,13 @@ public class ConferenceCell extends CharmListCell<Conference> {
             content.setOnMouseReleased(e -> {
                 if (!item.equals(service.getConference())) {
                     ConferenceLoadingLayer.show(service, item);
-                    service.retrieveConference(item.getId(), item.getCfpURL());
                     Services.get(SettingsService.class).ifPresent(settingsService -> {
                         settingsService.store(DevoxxSettings.SAVED_CONFERENCE_TYPE, item.getEventType().name());
                         settingsService.store(DevoxxSettings.SAVED_CONFERENCE_ID, String.valueOf(item.getId()));
                         settingsService.store(DevoxxSettings.SAVED_CONFERENCE_CFP_URL, String.valueOf(item.getCfpURL()));
                         settingsService.store(DevoxxSettings.SAVED_CONFERENCE_NAME, String.valueOf(item.getName()));
                     });
+                    service.retrieveConference(item.getId(), item.getCfpURL());
                 } else {
                     DevoxxView.SESSIONS.switchView();
                 }

--- a/DevoxxClientMobile/src/main/java/com/devoxx/views/layer/ConferenceLoadingLayer.java
+++ b/DevoxxClientMobile/src/main/java/com/devoxx/views/layer/ConferenceLoadingLayer.java
@@ -88,11 +88,15 @@ public class ConferenceLoadingLayer extends Layer {
         getChildren().addAll(background, progressIndicator, conferenceLabel);
 
         timeout = new PauseTransition(TIMEOUT);
-        timeout.setOnFinished(e -> hide());
+        timeout.setOnFinished(e -> {
+            hide();
+            DevoxxView.SESSIONS.switchView();
+        });
         // Listener helps for quick response in cases where data has been cached
         sessionsListener = o -> {
             if (service.retrieveSessions().size() > 0) {
                 doHide();
+                DevoxxView.SESSIONS.switchView();
             }
         };
         
@@ -142,7 +146,6 @@ public class ConferenceLoadingLayer extends Layer {
         if (timeout.getStatus() != STOPPED) timeout.stop();
         service.retrieveSessions().removeListener(sessionsListener);
         if (!isShowing()) return;
-        DevoxxView.SESSIONS.switchView();
         if (service.getConference() != null && isConferenceFromPast(service.getConference())) {
             showPastConferenceMessage();
         } else {


### PR DESCRIPTION
In case the "conference" RF fails, we do the following:

* switch to CONF_SELECTOR view
* hide ConferenceLoading layer
* show an alert to the user
* clear conference details from local storage when alert is closed