### PR TITLE
Append regex with "/api" to improve url matching

### DIFF
--- a/DevoxxClientMobile/src/main/java/com/devoxx/service/DevoxxService.java
+++ b/DevoxxClientMobile/src/main/java/com/devoxx/service/DevoxxService.java
@@ -689,7 +689,7 @@ public class DevoxxService implements Service {
     }
 
     private boolean isNewCfpURL(String cfp) {
-        return cfp.matches(".+?(?=.cfp.dev)(.*)");
+        return cfp.matches(".+?(?=.cfp.dev/api)(.*)");
     }
 
     private void updateSpeakerDetails(Speaker updatedSpeaker) {

--- a/DevoxxRemoteFunctions/src/main/java/com/gluonhq/devoxx/serverless/util/ConferenceUtil.java
+++ b/DevoxxRemoteFunctions/src/main/java/com/gluonhq/devoxx/serverless/util/ConferenceUtil.java
@@ -132,6 +132,6 @@ public class ConferenceUtil {
     }
     
     public static boolean isNewCfpURL(String cfp) {
-        return cfp.matches(".+?(?=.cfp.dev)(.*)");
+        return cfp.matches(".+?(?=.cfp.dev/api)(.*)");
     }
 }


### PR DESCRIPTION
Fix cfp url matching by appending "/api" to the regular expression.

This will help cfp url to not match cases like: `https://cfp.devoxx.ma/api`.

Fixes #267