### PR TITLE
Update lambda functions via Gradle tasks

### DIFF
--- a/DevoxxRemoteFunctions/build.gradle
+++ b/DevoxxRemoteFunctions/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         maven { url "https://plugins.gradle.org/m2/" }
     }
     dependencies {
-        classpath "jp.classmethod.aws:gradle-aws-plugin:0.+"
+        classpath "jp.classmethod.aws:gradle-aws-plugin:0.41"
     }
 }
 
@@ -16,10 +16,6 @@ apply plugin: 'jp.classmethod.aws.lambda'
 aws {
     profileName = "default"
     region = "eu-west-1"
-}
-
-lambda {
-    region = "us-east-1"
 }
 
 repositories {
@@ -50,7 +46,7 @@ task conferenceZip(type: Zip) {
 
 task updateConferenceLambda(type: AWSLambdaUpdateFunctionCodeTask, dependsOn: conferenceZip) {
     functionName = "devoxxConference"
-    zipFile = new File("$buildDir/distributions/conference.zip")
+    zipFile = conferenceZip.archivePath
 }
 
 task conferencesZip(type: Zip) {
@@ -67,7 +63,7 @@ task conferencesZip(type: Zip) {
 
 task updateConferencesLambda(type: AWSLambdaUpdateFunctionCodeTask, dependsOn: conferencesZip) {
     functionName = "devoxxAllConferences"
-    zipFile = new File("$buildDir/distributions/conferences.zip")
+    zipFile = conferencesZip.archivePath
 }
 
 task feedbackZip(type: Zip) {
@@ -83,7 +79,7 @@ task feedbackZip(type: Zip) {
 
 task updateFeedbackLambda(type: AWSLambdaUpdateFunctionCodeTask, dependsOn: feedbackZip) {
     functionName = "devoxxSendFeedback"
-    zipFile = new File("$buildDir/distributions/conferences.zip")
+    zipFile = feedbackZip.archivePath
 }
 
 task sessionsZip(type: Zip) {
@@ -100,7 +96,7 @@ task sessionsZip(type: Zip) {
 
 task updateSessionsLambda(type: AWSLambdaUpdateFunctionCodeTask, dependsOn: sessionsZip) {
     functionName = "devoxxRetrieveSessionsV2"
-    zipFile = new File("$buildDir/distributions/sessions.zip")
+    zipFile = sessionsZip.archivePath
 }
 
 task verifyaccountZip(type: Zip) {
@@ -116,7 +112,7 @@ task verifyaccountZip(type: Zip) {
 
 task updateVerifyaccountLambda(type: AWSLambdaUpdateFunctionCodeTask, dependsOn: verifyaccountZip) {
     functionName = "devoxxAccountCredentials"
-    zipFile = new File("$buildDir/distributions/verifyaccount.zip")
+    zipFile = verifyaccountZip.archivePath
 }
 
 task buildAwsLambda {
@@ -128,11 +124,7 @@ task buildAwsLambda {
 }
 
 task uploadAwsLambda {
-    dependsOn(
-            updateConferenceLambda, updateConferencesLambda,
-            updateFeedbackLambda, updateSessionsLambda,
-            updateVerifyaccountLambda
-    )
+    dependsOn tasks.withType(AWSLambdaUpdateFunctionCodeTask)
 }
 
 build.dependsOn buildAwsLambda

--- a/DevoxxRemoteFunctions/build.gradle
+++ b/DevoxxRemoteFunctions/build.gradle
@@ -1,4 +1,26 @@
+import jp.classmethod.aws.gradle.lambda.AWSLambdaUpdateFunctionCodeTask
+
+buildscript {
+    repositories {
+        mavenCentral()
+        maven { url "https://plugins.gradle.org/m2/" }
+    }
+    dependencies {
+        classpath "jp.classmethod.aws:gradle-aws-plugin:0.+"
+    }
+}
+
 apply plugin: 'java'
+apply plugin: 'jp.classmethod.aws.lambda'
+
+aws {
+    profileName = "default"
+    region = "eu-west-1"
+}
+
+lambda {
+    region = "us-east-1"
+}
 
 repositories {
     jcenter()
@@ -25,6 +47,11 @@ task conferenceZip(type: Zip) {
     }
 }
 
+task updateConferenceLambda(type: AWSLambdaUpdateFunctionCodeTask, dependsOn: conferenceZip) {
+    functionName = "devoxxConference"
+    zipFile = new File("$buildDir/distributions/conference.zip")
+}
+
 task conferencesZip(type: Zip) {
     archiveName = "conferences.zip"
     into ('') {
@@ -37,6 +64,11 @@ task conferencesZip(type: Zip) {
     }
 }
 
+task updateConferencesLambda(type: AWSLambdaUpdateFunctionCodeTask, dependsOn: conferencesZip) {
+    functionName = "devoxxAllConferences"
+    zipFile = new File("$buildDir/distributions/conferences.zip")
+}
+
 task feedbackZip(type: Zip) {
     archiveName = "feedback.zip"
     into ('') {
@@ -46,6 +78,11 @@ task feedbackZip(type: Zip) {
     into('lib') {
         from configurations.runtime
     }
+}
+
+task updateFeedbackLambda(type: AWSLambdaUpdateFunctionCodeTask, dependsOn: feedbackZip) {
+    functionName = "devoxxSendFeedback"
+    zipFile = new File("$buildDir/distributions/conferences.zip")
 }
 
 task sessionsZip(type: Zip) {
@@ -60,6 +97,11 @@ task sessionsZip(type: Zip) {
     }
 }
 
+task updateSessionsLambda(type: AWSLambdaUpdateFunctionCodeTask, dependsOn: sessionsZip) {
+    functionName = "devoxxRetrieveSessionsV2"
+    zipFile = new File("$buildDir/distributions/sessions.zip")
+}
+
 task verifyaccountZip(type: Zip) {
     archiveName = "verifyaccount.zip"
     into ('') {
@@ -71,11 +113,24 @@ task verifyaccountZip(type: Zip) {
     }
 }
 
+task updateVerifyaccountLambda(type: AWSLambdaUpdateFunctionCodeTask, dependsOn: verifyaccountZip) {
+    functionName = "devoxxAccountCredentials"
+    zipFile = new File("$buildDir/distributions/verifyaccount.zip")
+}
+
 task buildAwsLambda {
     dependsOn(
             conferenceZip, conferencesZip,
             feedbackZip, sessionsZip,
             verifyaccountZip
+    )
+}
+
+task uploadAwsLambda {
+    dependsOn(
+            updateConferenceLambda, updateConferencesLambda,
+            updateFeedbackLambda, updateSessionsLambda,
+            updateVerifyaccountLambda
     )
 }
 


### PR DESCRIPTION
This PR helps to update AWS lambda directly from the command line using Gradle tasks.

For this we need to create an AWS credentials file containing the values for aws access key and secret access key. The same can be found here: https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html