### PR TITLE
Remove html tags and escaped characters from talk summary

### DIFF
--- a/DevoxxRemoteFunctions/build.gradle
+++ b/DevoxxRemoteFunctions/build.gradle
@@ -11,6 +11,7 @@ dependencies {
     compile "org.glassfish:javax.json:1.1"
     compile 'com.amazonaws:aws-lambda-java-core:1.1.0'
     compile 'com.amazonaws:aws-java-sdk-ses:1.11.368'
+    compile 'org.jsoup:jsoup:1.12.1'
 }
 
 task conferenceZip(type: Zip) {

--- a/DevoxxRemoteFunctions/src/main/java/com/gluonhq/devoxx/serverless/sessions/SessionsLambda.java
+++ b/DevoxxRemoteFunctions/src/main/java/com/gluonhq/devoxx/serverless/sessions/SessionsLambda.java
@@ -44,7 +44,7 @@ public class SessionsLambda implements RequestStreamHandler {
 
     private static final String CONFERENCE_ID_OLD = "\"65\"";
     private static final String CFP_ENDPOINT_OLD = "https://vxdbanff19.confinabox.com/api";
-    private static final String CFP_ENDPOINT_NEW = "https://vxdms2019.cfp.dev/api/";
+    private static final String CFP_ENDPOINT_NEW = "https://dvbe19.cfp.dev/api/";
 
     public void handleRequest(InputStream input, OutputStream output, Context context) throws IOException {
         String conferenceId, cfpEndpoint;

--- a/DevoxxRemoteFunctions/src/main/java/com/gluonhq/devoxx/serverless/sessions/SessionsRetriever.java
+++ b/DevoxxRemoteFunctions/src/main/java/com/gluonhq/devoxx/serverless/sessions/SessionsRetriever.java
@@ -25,6 +25,9 @@
  */
 package com.gluonhq.devoxx.serverless.sessions;
 
+import org.jsoup.Jsoup;
+import org.jsoup.safety.Whitelist;
+
 import javax.json.*;
 import javax.json.stream.JsonCollectors;
 import javax.ws.rs.WebApplicationException;
@@ -154,13 +157,17 @@ public class SessionsRetriever {
         builder.add("trackId",       source.get("trackId"));
         builder.add("lang",          source.get("langName"));
         builder.add("audienceLevel", source.get("audienceLevel"));
-        builder.add("summary",       source.get("talkDescription"));
-        builder.add("summaryAsHtml", "");
+        builder.add("summary",       removeHTMLTags(source.getString("talkDescription")));
+        builder.add("summaryAsHtml", source.get("talkDescription"));
         builder.add("tags",
                 source.containsKey("tags") ? updateTags(source.getJsonArray("tags")) : emptyJsonArray());
         builder.add("speakers",
                 source.containsKey("speakers") ? updateSpeakers(source.getJsonArray("speakers")) : emptyJsonArray());
         return builder.build();
+    }
+
+    private String removeHTMLTags(String talkDescription) {
+        return Jsoup.clean(talkDescription, Whitelist.none());
     }
 
     private JsonArray updateTags(JsonArray tags) {


### PR DESCRIPTION
Talk summary in new cfp.dev endpoints contain html tags in them. For mobile app, we need to remove these tags.