### PR TITLE
When authentication fails, show Toast 

### DIFF
--- a/DevoxxClientMobile/src/main/java/com/devoxx/views/AuthenticatePresenter.java
+++ b/DevoxxClientMobile/src/main/java/com/devoxx/views/AuthenticatePresenter.java
@@ -140,10 +140,9 @@ public class AuthenticatePresenter extends GluonPresenter<DevoxxApplication> {
         response.setOnFailed(e -> {
             if (failure != null) {
                 failure.run();
-            } else {
-                Toast toast = new Toast(DevoxxBundle.getString("OTN.AUTHENTICATION.FAILURE"));
-                toast.show();
             }
+            Toast toast = new Toast(DevoxxBundle.getString("OTN.AUTHENTICATION.FAILURE"));
+            toast.show();
             appBar.setProgressBarVisible(false);
         });
     }


### PR DESCRIPTION
The toast should be shown irrespective of whether a failureRunnable exists.